### PR TITLE
Pass in ResponseWriter to Handler, allow handlers to override response body/status

### DIFF
--- a/githubapp/dispatcher.go
+++ b/githubapp/dispatcher.go
@@ -129,7 +129,9 @@ func (d *eventDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(status)
 		if len(respbody) != 0 {
-			w.Write(respbody)
+			if n, err := w.Write(respbody); n != len(respbody) || err != nil {
+				logger.Info().Err(err).Msg("error writing response or short write")
+			}
 		}
 	case eventType == "ping":
 		w.WriteHeader(http.StatusOK)

--- a/githubapp/middleware.go
+++ b/githubapp/middleware.go
@@ -92,7 +92,7 @@ func ClientLogging(lvl zerolog.Level) ClientMiddleware {
 		return roundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			start := time.Now()
 			res, err := next.RoundTrip(r)
-			elapsed := time.Now().Sub(start)
+			elapsed := time.Since(start)
 
 			log := zerolog.Ctx(r.Context())
 			if res != nil {


### PR DESCRIPTION
- Allow handlers to modify webhook responses directly via http.ResponseWriter.
- Let handlers optionally override the response body as well as status code if needed.
- Return a better response status for webhook validation errors (400 Bad Request instead of 500 Internal Server Error) and avoid the error handler in that case.