### PR TITLE
Client caching as config option instead of middleware

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -53,6 +53,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:a2b4fa8b538f6e42d0f38cbdef92e771072d7a64a97ff1512da95554ab2680a1"
+  name = "github.com/gregjones/httpcache"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "901d90724c7919163f472a9812253fb26761123d"
+
+[[projects]]
   digest = "1:b42cde0e1f3c816dd57f57f7bbcf05ca40263ad96f168714c130c611fc0856a6"
   name = "github.com/hashicorp/golang-lru"
   packages = [
@@ -211,6 +219,7 @@
     "github.com/alexedwards/scs",
     "github.com/bradleyfalzon/ghinstallation",
     "github.com/google/go-github/github",
+    "github.com/gregjones/httpcache",
     "github.com/hashicorp/golang-lru",
     "github.com/palantir/go-baseapp/baseapp",
     "github.com/pkg/errors",

--- a/README.md
+++ b/README.md
@@ -143,13 +143,13 @@ distinct clients:
 These are provided when calling `githubapp.NewClientCreator`:
 
 - `githubapp.WithClientUserAgent` sets a `User-Agent` string for all clients
+- `githubapp.WithClientCaching` sets an HTTP cache for all clients
 - `githubapp.WithClientMiddleware` allows customization of the
   `http.RoundTripper` used by all clients and is useful if you want to log
   requests or emit metrics about GitHub requests and responses.
 
 The library provides the following middleware:
 
-- `githubapp.ClientCaching` sets an HTTP cache
 - `githubapp.ClientMetrics` emits the standard metrics described below
 - `githubapp.ClientLogging` logs metadata about all requests and responses
 
@@ -157,8 +157,8 @@ The library provides the following middleware:
 baseHandler, err := githubapp.NewDefaultCachingClientCreator(
     config.Github,
     githubapp.WithClientUserAgent("example-app/1.0.0"),
+    githubapp.WithClientCaching(func() httpcache.Cache { return httpcache.NewMemoryCache() }),
     githubapp.WithClientMiddleware(
-        githubapp.ClientCaching(func() httpcache.Cache { return httpcache.NewMemoryCache() }),
         githubapp.ClientMetrics(registry),
         githubapp.ClientLogging(zerolog.DebugLevel),
     ),
@@ -179,7 +179,7 @@ middleware.
 | `github.requests.3xx` | `counter` | like `github.requests`, but only counting 3XX status codes |
 | `github.requests.4xx` | `counter` | like `github.requests`, but only counting 4XX status codes |
 | `github.requests.5xx` | `counter` | like `github.requests`, but only counting 5XX status codes |
-| `github.requests.cached` | `counter` | the count of cached HTTP requess |
+| `github.requests.cached` | `counter` | the count of cached HTTP requests |
 
 Note that metrics need to be published in order to be useful. Several
 [publishing options][] are available or you can implement your own.

--- a/README.md
+++ b/README.md
@@ -143,9 +143,10 @@ distinct clients:
 These are provided when calling `githubapp.NewClientCreator`:
 
 - `githubapp.WithClientUserAgent` sets a `User-Agent` string for all clients
-- `githubapp.WithClientCaching` sets an HTTP cache for all clients,
-  alwaysValidate is used to determine if the cached responses from
-  Github should be used or if all requests should be re-validated
+- `githubapp.WithClientCaching` enables response caching for all v3 (REST) clients.
+   The cache can be configured to always validate responses or to respect
+   the cache headers returned by GitHub. Re-validation is useful if data
+   often changes faster than the requested cache duration.
 - `githubapp.WithClientMiddleware` allows customization of the
   `http.RoundTripper` used by all clients and is useful if you want to log
   requests or emit metrics about GitHub requests and responses.
@@ -159,8 +160,6 @@ The library provides the following middleware:
 baseHandler, err := githubapp.NewDefaultCachingClientCreator(
     config.Github,
     githubapp.WithClientUserAgent("example-app/1.0.0"),
-    // Cache responses from Github in memory, and disable cache validation
-    // to force Conditional Requests
     githubapp.WithClientCaching(false, func() httpcache.Cache { return httpcache.NewMemoryCache() }),
     githubapp.WithClientMiddleware(
         githubapp.ClientMetrics(registry),

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ distinct clients:
 These are provided when calling `githubapp.NewClientCreator`:
 
 - `githubapp.WithClientUserAgent` sets a `User-Agent` string for all clients
-- `githubapp.WithClientCaching` sets an HTTP cache for all clients
+- `githubapp.WithClientCaching` sets an HTTP cache for all clients,
+  alwaysValidate is used to determine if the cached responses from
+  Github should be used or if all requests should be re-validated
 - `githubapp.WithClientMiddleware` allows customization of the
   `http.RoundTripper` used by all clients and is useful if you want to log
   requests or emit metrics about GitHub requests and responses.
@@ -157,6 +159,8 @@ The library provides the following middleware:
 baseHandler, err := githubapp.NewDefaultCachingClientCreator(
     config.Github,
     githubapp.WithClientUserAgent("example-app/1.0.0"),
+    // Cache responses from Github in memory, and disable cache validation
+    // to force Conditional Requests
     githubapp.WithClientCaching(false, func() httpcache.Cache { return httpcache.NewMemoryCache() }),
     githubapp.WithClientMiddleware(
         githubapp.ClientMetrics(registry),
@@ -179,6 +183,7 @@ middleware.
 | `github.requests.3xx` | `counter` | like `github.requests`, but only counting 3XX status codes |
 | `github.requests.4xx` | `counter` | like `github.requests`, but only counting 4XX status codes |
 | `github.requests.5xx` | `counter` | like `github.requests`, but only counting 5XX status codes |
+| `github.requests.cached` | `counter` | the count of successfully cached requests |
 
 Note that metrics need to be published in order to be useful. Several
 [publishing options][] are available or you can implement your own.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The library provides the following middleware:
 baseHandler, err := githubapp.NewDefaultCachingClientCreator(
     config.Github,
     githubapp.WithClientUserAgent("example-app/1.0.0"),
-    githubapp.WithClientCaching(func() httpcache.Cache { return httpcache.NewMemoryCache() }),
+    githubapp.WithClientCaching(false, func() httpcache.Cache { return httpcache.NewMemoryCache() }),
     githubapp.WithClientMiddleware(
         githubapp.ClientMetrics(registry),
         githubapp.ClientLogging(zerolog.DebugLevel),

--- a/example/config.yml
+++ b/example/config.yml
@@ -1,5 +1,5 @@
 server:
-  address: "0.0.0.0"
+  address: "127.0.0.1"
   port: 8080
   public_url: "http://localhost:8080"
 

--- a/example/main.go
+++ b/example/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"os"
 
+	"github.com/gregjones/httpcache"
 	"github.com/palantir/go-baseapp/baseapp"
 	"github.com/rs/zerolog"
 	"goji.io/pat"

--- a/example/main.go
+++ b/example/main.go
@@ -44,7 +44,7 @@ func main() {
 	cc, err := githubapp.NewDefaultCachingClientCreator(
 		config.Github,
 		githubapp.WithClientUserAgent("example-app/1.0.0"),
-		githubapp.WithClientCaching(func() httpcache.Cache { return httpcache.NewMemoryCache() }),
+		githubapp.WithClientCaching(false, func() httpcache.Cache { return httpcache.NewMemoryCache() }),
 		githubapp.WithClientMiddleware(
 			githubapp.ClientMetrics(server.Registry()),
 		),
@@ -62,5 +62,8 @@ func main() {
 	server.Mux().Handle(pat.Post(githubapp.DefaultWebhookRoute), webhookHandler)
 
 	// Start is blocking
-	_ = server.Start()
+	err = server.Start()
+	if err != nil {
+		panic(err)
+	}
 }

--- a/example/main.go
+++ b/example/main.go
@@ -44,9 +44,9 @@ func main() {
 	cc, err := githubapp.NewDefaultCachingClientCreator(
 		config.Github,
 		githubapp.WithClientUserAgent("example-app/1.0.0"),
+		githubapp.WithClientCaching(func() httpcache.Cache { return httpcache.NewMemoryCache() }),
 		githubapp.WithClientMiddleware(
 			githubapp.ClientMetrics(server.Registry()),
-			githubapp.ClientCaching(func() httpcache.Cache { return httpcache.NewMemoryCache() }),
 		),
 	)
 	if err != nil {

--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -169,7 +169,7 @@ func (c *clientCreator) NewAppClient() (*github.Client, error) {
 	installation, transportError := newAppInstallation(c.integrationID, c.privKeyBytes, c.v3BaseURL)
 	middleware := append(c.middleware, installation)
 	if c.cacheFunc != nil {
-		middleware = append(c.middleware, cache(c.cacheFunc), cacheControl(c.alwaysValidate))
+		middleware = append(middleware, cache(c.cacheFunc), cacheControl(c.alwaysValidate))
 	}
 
 	client, err := c.newClient(base, middleware, "application", 0)
@@ -207,7 +207,7 @@ func (c *clientCreator) NewInstallationClient(installationID int64) (*github.Cli
 	installation, transportError := newInstallation(c.integrationID, int(installationID), c.privKeyBytes, c.v3BaseURL)
 	middleware := append(c.middleware, installation)
 	if c.cacheFunc != nil {
-		middleware = append(c.middleware, cache(c.cacheFunc), cacheControl(c.alwaysValidate))
+		middleware = append(middleware, cache(c.cacheFunc), cacheControl(c.alwaysValidate))
 	}
 
 	client, err := c.newClient(base, middleware, fmt.Sprintf("installation: %d", installationID), installationID)

--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -172,8 +172,8 @@ func (c *clientCreator) NewAppClient() (*github.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	if transportError != nil {
-		return nil, transportError
+	if *transportError != nil {
+		return nil, *transportError
 	}
 	return client, nil
 }
@@ -191,8 +191,8 @@ func (c *clientCreator) NewAppV4Client() (*githubv4.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	if transportError != nil {
-		return nil, transportError
+	if *transportError != nil {
+		return nil, *transportError
 	}
 	return client, nil
 }
@@ -210,8 +210,8 @@ func (c *clientCreator) NewInstallationClient(installationID int64) (*github.Cli
 	if err != nil {
 		return nil, err
 	}
-	if transportError != nil {
-		return nil, transportError
+	if *transportError != nil {
+		return nil, *transportError
 	}
 	return client, nil
 }
@@ -229,8 +229,8 @@ func (c *clientCreator) NewInstallationV4Client(installationID int64) (*githubv4
 	if err != nil {
 		return nil, err
 	}
-	if transportError != nil {
-		return nil, transportError
+	if *transportError != nil {
+		return nil, *transportError
 	}
 	return client, nil
 }
@@ -283,7 +283,7 @@ func applyMiddleware(base *http.Client, middleware []ClientMiddleware) {
 	}
 }
 
-func newAppInstallation(integrationID int, privKeyBytes []byte, v3BaseURL string) (ClientMiddleware, error) {
+func newAppInstallation(integrationID int, privKeyBytes []byte, v3BaseURL string) (ClientMiddleware, *error) {
 	var transportError error
 	installation := func(next http.RoundTripper) http.RoundTripper {
 		itr, err := ghinstallation.NewAppsTransport(next, integrationID, privKeyBytes)
@@ -295,10 +295,10 @@ func newAppInstallation(integrationID int, privKeyBytes []byte, v3BaseURL string
 		itr.BaseURL = strings.TrimSuffix(v3BaseURL, "/")
 		return itr
 	}
-	return installation, transportError
+	return installation, &transportError
 }
 
-func newInstallation(integrationID, installationID int, privKeyBytes []byte, v3BaseURL string) (ClientMiddleware, error) {
+func newInstallation(integrationID, installationID int, privKeyBytes []byte, v3BaseURL string) (ClientMiddleware, *error) {
 	var transportError error
 	installation := func(next http.RoundTripper) http.RoundTripper {
 		itr, err := ghinstallation.New(next, integrationID, installationID, privKeyBytes)
@@ -310,7 +310,7 @@ func newInstallation(integrationID, installationID int, privKeyBytes []byte, v3B
 		itr.BaseURL = strings.TrimSuffix(v3BaseURL, "/")
 		return itr
 	}
-	return installation, transportError
+	return installation, &transportError
 }
 
 func cache(cacheFunc func() httpcache.Cache) ClientMiddleware {

--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -325,7 +325,7 @@ func cacheControl(alwaysValidate bool) ClientMiddleware {
 			cacheControl := resp.Header.Get("Cache-Control")
 			if cacheControl != "" {
 				newCacheControl := maxAgeRegex.ReplaceAllString(cacheControl, "max-age=0")
-				resp.Header.Set("Cache-Control", string(newCacheControl))
+				resp.Header.Set("Cache-Control", newCacheControl)
 			}
 			return resp, err
 		})

--- a/githubapp/middleware.go
+++ b/githubapp/middleware.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gregjones/httpcache"
 	"github.com/rcrowley/go-metrics"
 	"github.com/rs/zerolog"
 )
@@ -28,6 +29,8 @@ const (
 	MetricsKeyRequests3xx = "github.requests.3xx"
 	MetricsKeyRequests4xx = "github.requests.4xx"
 	MetricsKeyRequests5xx = "github.requests.5xx"
+
+	MetricsKeyRequestsCached = "github.requests.cached"
 )
 
 // ClientMetrics creates client middleware that records metrics about all
@@ -39,6 +42,7 @@ func ClientMetrics(registry metrics.Registry) ClientMiddleware {
 		MetricsKeyRequests3xx,
 		MetricsKeyRequests4xx,
 		MetricsKeyRequests5xx,
+		MetricsKeyRequestsCached,
 	} {
 		// Use GetOrRegister for thread-safety when creating multiple
 		// RoundTrippers that share the same registry
@@ -53,6 +57,10 @@ func ClientMetrics(registry metrics.Registry) ClientMiddleware {
 				registry.Get(MetricsKeyRequests).(metrics.Counter).Inc(1)
 				if key := bucketStatus(res.StatusCode); key != "" {
 					registry.Get(key).(metrics.Counter).Inc(1)
+				}
+
+				if res.Header.Get(httpcache.XFromCache) != "" {
+					registry.Get(MetricsKeyRequestsCached).(metrics.Counter).Inc(1)
 				}
 			}
 

--- a/githubapp/middleware.go
+++ b/githubapp/middleware.go
@@ -118,16 +118,6 @@ func ClientLogging(lvl zerolog.Level) ClientMiddleware {
 	}
 }
 
-// ClientCaching creates client middleware that caches http responses
-// using the provided cache implementation
-func ClientCaching(cache func() httpcache.Cache) ClientMiddleware {
-	return func(next http.RoundTripper) http.RoundTripper {
-		cached := httpcache.NewTransport(cache())
-		cached.Transport = next
-		return cached
-	}
-}
-
 type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (fn roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {


### PR DESCRIPTION
The middleware approach fails to correct detect cached response
when the authorization header is set too late in the roundtrip