### PR TITLE
Fix ordering of installation ID middleware

### DIFF
--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -252,7 +252,7 @@ func (c *clientCreator) NewTokenV4Client(token string) (*githubv4.Client, error)
 }
 
 func (c *clientCreator) newClient(base *http.Client, middleware []ClientMiddleware, details string, installID int64) (*github.Client, error) {
-	middleware = append(middleware, setInstallationID(installID))
+	middleware = append([]ClientMiddleware{setInstallationID(installID)}, middleware...)
 	applyMiddleware(base, middleware)
 
 	baseURL, err := url.Parse(c.v3BaseURL)


### PR DESCRIPTION
This must come first in the stack so that the value is available to
the metrics middleware added by users.