### PR TITLE
Fix example functionality

### DIFF
--- a/example/issue_comment.go
+++ b/example/issue_comment.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/google/go-github/github"
 	"github.com/pkg/errors"
@@ -68,8 +69,8 @@ func (h *PRCommentHandler) Handle(ctx context.Context, eventType, deliveryID str
 	author := event.GetComment().GetUser().GetLogin()
 	body := event.GetComment().GetBody()
 
-	if author[len(author)-5:] == "[bot]" {
-		logger.Debug().Err(err).Msg("Issue comment was created by a bot")
+	if strings.HasSuffix(author, "[bot]") {
+		logger.Debug().Msg("Issue comment was created by a bot")
 		return nil
 	}
 

--- a/example/issue_comment.go
+++ b/example/issue_comment.go
@@ -65,16 +65,21 @@ func (h *PRCommentHandler) Handle(ctx context.Context, eventType, deliveryID str
 
 	repoOwner := repo.GetOwner().GetLogin()
 	repoName := repo.GetName()
-	author := event.GetComment().GetUser()
+	author := event.GetComment().GetUser().GetLogin()
 	body := event.GetComment().GetBody()
 
+	if author[len(author)-5:] == "[bot]" {
+		zerolog.Ctx(ctx).Debug().Msg("Issue comment was created by a bot")
+		return nil
+	}
+
 	logger.Debug().Msgf("Echoing comment on %s/%s#%d by %s", repoOwner, repoName, prNum, author)
-	msg := fmt.Sprintf("%s\n%s said\n```%s\n```\n", h.preamble, author, body)
-	prComment := github.PullRequestComment{
+	msg := fmt.Sprintf("%s\n%s said\n```\n%s\n```\n", h.preamble, author, body)
+	prComment := github.IssueComment{
 		Body: &msg,
 	}
 
-	if _, _, err := client.PullRequests.CreateComment(ctx, repoOwner, repoName, prNum, &prComment); err != nil {
+	if _, _, err := client.Issues.CreateComment(ctx, repoOwner, repoName, prNum, &prComment); err != nil {
 		logger.Error().Err(err).Msg("Failed to comment on pull request")
 	}
 

--- a/example/issue_comment.go
+++ b/example/issue_comment.go
@@ -69,7 +69,7 @@ func (h *PRCommentHandler) Handle(ctx context.Context, eventType, deliveryID str
 	body := event.GetComment().GetBody()
 
 	if author[len(author)-5:] == "[bot]" {
-		zerolog.Ctx(ctx).Debug().Msg("Issue comment was created by a bot")
+		logger.Debug().Err(err).Msg("Issue comment was created by a bot")
 		return nil
 	}
 


### PR DESCRIPTION
This fixes the example API call, cleans up the logging, and adds a check to ensure it doesn’t loop forever on its own comments