### PR TITLE
Support custom responses from event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,25 @@ secure `StateStore` implementation. `oauth2.SessionStateStore` is a good choice
 that uses [alexedwards/scs](https://github.com/alexedwards/scs) to store the
 state in a session.
 
+## Customizing Webhook Responses
+
+For most applications, the default responses should be sufficient: they use
+correct status codes and include enough information to match up GitHub delivery
+records with request logs. If your application has additional requirements for
+responses, two methods are provided for customization:
+
+- Error responses can be modified with a custom error callback. Use the
+  `WithErrorCallback` option when creating an event dispatcher.
+
+- Non-error responses can be modified with a custom response callback. Use the
+  `WithResponseCallback` option when creating an event dispatcher.
+
+- Individual hook responses can be modified by calling the `SetResponder`
+  function before the handler returns. Note that if you register a custom
+  response handler as described above, you must make it aware of handler-level
+  responders if you want to keep using `SetResponder`. See the default response
+  callback for an example of how to implement this.
+
 ## Stability and Versioning Guarantees
 
 While we've used this library to build multiple applications internally,

--- a/githubapp/dispatcher.go
+++ b/githubapp/dispatcher.go
@@ -121,6 +121,8 @@ func (d *eventDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	// initialize context for SetResponder/GetResponder
+	// we store a pointer in the context so that functions deeper in the call
+	// tree can modify the value without creating a new context
 	var responder func(http.ResponseWriter, *http.Request)
 	ctx = context.WithValue(ctx, responderKey{}, &responder)
 	r = r.WithContext(ctx)

--- a/githubapp/dispatcher.go
+++ b/githubapp/dispatcher.go
@@ -41,16 +41,47 @@ type EventHandler interface {
 	Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error
 }
 
-type ErrorHandler func(http.ResponseWriter, *http.Request, error)
+// ErrorCallback is called when an event handler returns an error. The error
+// from the handler is passed directly as the final argument.
+type ErrorCallback func(w http.ResponseWriter, r *http.Request, err error)
+
+// ResponseCallback is called to send a response to GitHub after an event is
+// handled. It is passed the event type and a flag indicating if an event
+// handler was called for the event.
+type ResponseCallback func(w http.ResponseWriter, r *http.Request, event string, handled bool)
+
+// DispatcherOption configures properties of an event dispatcher.
+type DispatcherOption func(*eventDispatcher)
+
+// WithErrorCallback sets the error callback for an event dispatcher.
+func WithErrorCallback(onError ErrorCallback) DispatcherOption {
+	return func(d *eventDispatcher) {
+		if onError != nil {
+			d.onError = onError
+		}
+	}
+}
+
+// WithResponseCallback sets the response callback for an event dispatcher.
+func WithResponseCallback(onResponse ResponseCallback) DispatcherOption {
+	return func(d *eventDispatcher) {
+		if onResponse != nil {
+			d.onResponse = onResponse
+		}
+	}
+}
 
 type eventDispatcher struct {
 	handlerMap map[string]EventHandler
 	secret     string
-	onError    ErrorHandler
+
+	onError    ErrorCallback
+	onResponse ResponseCallback
 }
 
-// NewDefaultEventDispatcher is a convenience method to create an
-// EventDispatcher from configuration using the default error handler.
+// NewDefaultEventDispatcher is a convenience method to create an event
+// dispatcher from configuration using the default error and response
+// callbacks.
 func NewDefaultEventDispatcher(c Config, handlers ...EventHandler) http.Handler {
 	return NewEventDispatcher(handlers, c.App.WebhookSecret, nil)
 }
@@ -59,10 +90,9 @@ func NewDefaultEventDispatcher(c Config, handlers ...EventHandler) http.Handler 
 // requests to the appropriate event handlers. It validates payload integrity
 // using the given secret value.
 //
-// If an error occurs during handling, the error handler is called with the
-// error and should write an appropriate response. If the error handler is nil,
-// a default handler is used.
-func NewEventDispatcher(handlers []EventHandler, secret string, onError ErrorHandler) http.Handler {
+// Responses are controlled by optional error and response callbacks. If these
+// options are not provided, default callbacks are used.
+func NewEventDispatcher(handlers []EventHandler, secret string, opts ...DispatcherOption) http.Handler {
 	handlerMap := make(map[string]EventHandler)
 
 	// Iterate in reverse so the first entries in the slice have priority
@@ -72,35 +102,44 @@ func NewEventDispatcher(handlers []EventHandler, secret string, onError ErrorHan
 		}
 	}
 
-	if onError == nil {
-		onError = DefaultErrorHandler
-	}
-
-	return &eventDispatcher{
+	d := &eventDispatcher{
 		handlerMap: handlerMap,
 		secret:     secret,
-		onError:    onError,
+		onError:    DefaultErrorCallback,
+		onResponse: DefaultResponseCallback,
 	}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
 }
 
-// ServeHTTP to implement http.Handler
+// ServeHTTP processes a webhook request from GitHub.
 func (d *eventDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	// initialize context for SetResponder/GetResponder
+	var responder func(http.ResponseWriter, *http.Request)
+	ctx = context.WithValue(ctx, responderKey{}, &responder)
+	r = r.WithContext(ctx)
+
 	eventType := r.Header.Get("X-GitHub-Event")
+	deliveryID := r.Header.Get("X-GitHub-Delivery")
+
 	if eventType == "" {
 		// ACK payload that was received but won't be processed
 		w.WriteHeader(http.StatusAccepted)
 		return
 	}
-	deliveryID := r.Header.Get("X-GitHub-Delivery")
 
 	logger := zerolog.Ctx(ctx).With().
 		Str(LogKeyEventType, eventType).
 		Str(LogKeyDeliveryID, deliveryID).
 		Logger()
 
-	// update context and request to contain new log fields
+	// initialize context with event logger
 	ctx = logger.WithContext(ctx)
 	r = r.WithContext(ctx)
 
@@ -111,28 +150,65 @@ func (d *eventDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logger.Info().Msgf("Received webhook event")
-	handler, ok := d.handlerMap[eventType]
 
-	switch {
-	case ok:
+	handler, ok := d.handlerMap[eventType]
+	if ok {
 		if err := handler.Handle(ctx, eventType, deliveryID, payloadBytes); err != nil {
-			// pass error directly so handler can inspect types if needed
 			d.onError(w, r, err)
 			return
 		}
-		w.WriteHeader(http.StatusOK)
-	case eventType == "ping":
-		w.WriteHeader(http.StatusOK)
-	default:
+	}
+	d.onResponse(w, r, eventType, ok)
+}
+
+// DefaultErrorCallback logs errors and responds with a 500 status code.
+func DefaultErrorCallback(w http.ResponseWriter, r *http.Request, err error) {
+	logger := zerolog.Ctx(r.Context())
+	logger.Error().Err(err).Msg("Unexpected error handling webhook request")
+	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+}
+
+// DefaultResponseCallback responds with a 200 OK for handled events and a 202
+// Accepted status for all other events. By default, responses are empty.
+// Event handlers may send custom responses by calling the SetResponder
+// function before returning.
+func DefaultResponseCallback(w http.ResponseWriter, r *http.Request, event string, handled bool) {
+	if !handled && event != "ping" {
 		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	if res := GetResponder(r.Context()); res != nil {
+		res(w, r)
+	} else {
+		w.WriteHeader(http.StatusOK)
 	}
 }
 
-// DefaultErrorHandler logs errors and responds with a 500 status code.
-func DefaultErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
-	logger := zerolog.Ctx(r.Context())
-	logger.Error().Err(err).Msg("Unexpected error handling webhook request")
+type responderKey struct{}
 
-	msg := http.StatusText(http.StatusInternalServerError)
-	http.Error(w, msg, http.StatusInternalServerError)
+// SetResponder sets a function that sends a response to GitHub after event
+// processing completes. This function may only be called from event handler
+// functions invoked by the event dispatcher.
+//
+// Customizing individual handler responses should be rare. Applications that
+// want to modify the standard responses should consider registering a response
+// callback before using this function.
+func SetResponder(ctx context.Context, responder func(http.ResponseWriter, *http.Request)) {
+	r, ok := ctx.Value(responderKey{}).(*func(http.ResponseWriter, *http.Request))
+	if !ok || r == nil {
+		panic("SetResponder() must be called from an event handler invoked by the go-githubapp event dispatcher")
+	}
+	*r = responder
+}
+
+// GetResponder returns the response function that was set by an event handler.
+// If no response function exists, it returns nil. There is usually no reason
+// to call this outside of a response callback implementation.
+func GetResponder(ctx context.Context) func(http.ResponseWriter, *http.Request) {
+	r, ok := ctx.Value(responderKey{}).(*func(http.ResponseWriter, *http.Request))
+	if !ok || r == nil {
+		return nil
+	}
+	return *r
 }

--- a/githubapp/dispatcher_test.go
+++ b/githubapp/dispatcher_test.go
@@ -1,0 +1,218 @@
+// Copyright 2019 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubapp
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+const (
+	testHookSecret = "secrethooksecret"
+)
+
+func TestEventDispatcher(t *testing.T) {
+	tests := map[string]struct {
+		Handler TestEventHandler
+		Options []DispatcherOption
+		Event   string
+
+		ResponseCode int
+		ResponseBody string
+		CallCount    int
+	}{
+		"unhandledEvent": {
+			Handler: TestEventHandler{
+				Types: []string{"pull_request"},
+			},
+			Event:        "issue_comment",
+			ResponseCode: 202,
+		},
+		"pingIsHandled": {
+			Handler: TestEventHandler{
+				Types: []string{"pull_request"},
+			},
+			Event:        "ping",
+			ResponseCode: 200,
+		},
+		"callsRegisteredHandler": {
+			Handler: TestEventHandler{
+				Types: []string{"pull_request"},
+			},
+			Event:        "pull_request",
+			ResponseCode: 200,
+			CallCount:    1,
+		},
+		"defaultErrorHandlerReturns500": {
+			Handler: TestEventHandler{
+				Types: []string{"pull_request"},
+				Fn: func(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+					return errors.New("handler failure")
+				},
+			},
+			Event:        "pull_request",
+			ResponseCode: 500,
+			ResponseBody: "Internal Server Error\n",
+			CallCount:    1,
+		},
+		"callsCustomErrorCallback": {
+			Handler: TestEventHandler{
+				Types: []string{"pull_request"},
+				Fn: func(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+					return errors.New("handler failure")
+				},
+			},
+			Options: []DispatcherOption{
+				WithErrorCallback(func(w http.ResponseWriter, r *http.Request, err error) {
+					http.Error(w, "Already processed this pull request!", 409)
+				}),
+			},
+			Event:        "pull_request",
+			ResponseCode: 409,
+			ResponseBody: "Already processed this pull request!\n",
+			CallCount:    1,
+		},
+		"callsCustomResponseCallbackHandled": {
+			Handler: TestEventHandler{
+				Types: []string{"pull_request"},
+			},
+			Options: []DispatcherOption{
+				WithResponseCallback(func(w http.ResponseWriter, r *http.Request, event string, handled bool) {
+					if handled {
+						http.Error(w, fmt.Sprintf("Created an entry for the %s event!", event), 201)
+					} else {
+						http.Error(w, fmt.Sprintf("No handler for the %s event!", event), 404)
+					}
+				}),
+			},
+			Event:        "pull_request",
+			ResponseCode: 201,
+			ResponseBody: "Created an entry for the pull_request event!\n",
+			CallCount:    1,
+		},
+		"callsCustomResponseCallbackNotHandled": {
+			Handler: TestEventHandler{
+				Types: []string{"pull_request"},
+			},
+			Options: []DispatcherOption{
+				WithResponseCallback(func(w http.ResponseWriter, r *http.Request, event string, handled bool) {
+					if handled {
+						http.Error(w, fmt.Sprintf("Created an entry for the %s event!", event), 201)
+					} else {
+						http.Error(w, fmt.Sprintf("No handler for the %s event!", event), 404)
+					}
+				}),
+			},
+			Event:        "issue_comment",
+			ResponseCode: 404,
+			ResponseBody: "No handler for the issue_comment event!\n",
+		},
+		"callsHandlerResponder": {
+			Handler: TestEventHandler{
+				Types: []string{"pull_request"},
+				Fn: func(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+					SetResponder(ctx, func(w http.ResponseWriter, r *http.Request) {
+						http.Error(w, "I'm a teapot!", 418)
+					})
+					return nil
+				},
+			},
+			Event:        "pull_request",
+			ResponseCode: 418,
+			ResponseBody: "I'm a teapot!\n",
+			CallCount:    1,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			h := test.Handler
+			d := NewEventDispatcher([]EventHandler{&h}, testHookSecret, test.Options...)
+
+			req := newSignedRequest(test.Event, name)
+			res := httptest.NewRecorder()
+			d.ServeHTTP(res, req)
+
+			if test.ResponseCode != res.Code {
+				t.Errorf("incorrect response code: expected %d, actual %d", test.ResponseCode, res.Code)
+			}
+			if test.ResponseBody != res.Body.String() {
+				t.Errorf("incorrect response body:\nexpected: %q\n  actual: %q", test.ResponseBody, res.Body.String())
+			}
+			if test.CallCount != h.Count {
+				t.Errorf("incorrect call count: expected %d, actual %d", test.CallCount, h.Count)
+			}
+		})
+	}
+}
+
+func TestSetAndGetResponder(t *testing.T) {
+	t.Run("setPanicsOutsideOfDispatcher", func(t *testing.T) {
+		defer func() {
+			if err := recover(); err == nil {
+				t.Errorf("expected SetResponder to panic, but it did not!")
+			}
+		}()
+
+		ctx := context.Background()
+		SetResponder(ctx, func(w http.ResponseWriter, r *http.Request) {})
+	})
+}
+
+func newSignedRequest(eventType, id string) *http.Request {
+	body := []byte(fmt.Sprintf(`{"type":"%s"}`, eventType))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/github/hook", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Github-Event", eventType)
+	req.Header.Set("X-Github-Delivery", id)
+
+	mac := hmac.New(sha1.New, []byte(testHookSecret))
+	mac.Write(body)
+	req.Header.Set("X-Hub-Signature", fmt.Sprintf("sha1=%x", mac.Sum(nil)))
+
+	log := zerolog.New(os.Stdout)
+	req = req.WithContext(log.WithContext(req.Context()))
+
+	return req
+}
+
+type TestEventHandler struct {
+	Types []string
+	Fn    func(context.Context, string, string, []byte) error
+	Count int
+}
+
+func (h *TestEventHandler) Handles() []string {
+	return h.Types
+}
+
+func (h *TestEventHandler) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
+	h.Count++
+	if h.Fn != nil {
+		return h.Fn(ctx, eventType, deliveryID, payload)
+	}
+	return nil
+}


### PR DESCRIPTION
This introduces two new mechanisms for customizing responses:

  * Clients can configure a response callback to send custom responses
    for all events.
  * Individual handlers may call SetResponder() to send custom responses
    in specific situations.

While there should be little need to customize responses, I believe some
combination of these two options will satisfy most use cases. Note that
introducing the new callback changes the signature of NewEventDispatcher
and some other types; most applications are not using these directly.

On the other hand, I chose to introduce SetResponder() to avoid breaking
the EventHandler interface, even though it is more idiomatic to either
provide the handler with access to the request and response writer or
allow it to return more information.