### PR TITLE
Handling oauth during app installation

### DIFF
--- a/oauth2/sessions.go
+++ b/oauth2/sessions.go
@@ -49,6 +49,10 @@ func (s *SessionStateStore) VerifyState(r *http.Request, expected string) (bool,
 
 	state, err := sess.GetString(DefaultSessionKey)
 	if err != nil {
+		if len(expected) == 0 {
+			return true, nil
+		}
+
 		return false, err
 	}
 


### PR DESCRIPTION
This PR fixes error that occurs when github triggers oauth flow during the app installation.

From the documentation: https://developer.github.com/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps/

> Note: If you select Request user authorization (OAuth) during installation when creating or modifying your app, GitHub returns a temporary code that you will need to exchange for an access token. **The state parameter is not returned when GitHub initiates the OAuth flow during app installation.**