### PR TITLE
Add constraint for bradleyfalzon/ghinstallation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,15 +2,15 @@
 
 
 [[projects]]
-  digest = "1:4cbe55f096a604d401cb62fbc74c0f63c0ac3aa5a7d6891d96a34de009282fdc"
+  digest = "1:52a8efd8a7ddb4a3e0144541474335359f49836de8daf56b6ba0dd9c047d3d9b"
   name = "github.com/alexedwards/scs"
   packages = [
     ".",
     "stores/cookiestore",
   ]
   pruneopts = "NUT"
-  revision = "a01923edcb7f83c0c6ae7e70ad03f293e6ec9e26"
-  version = "v1.3.0"
+  revision = "cfcbf41460ffe695c7d52159fbff3393c646c8f0"
+  version = "v1.4.1"
 
 [[projects]]
   branch = "master"
@@ -21,12 +21,12 @@
   revision = "ffb42d5bb417aa8e12b3b7ff73d028b915dafa10"
 
 [[projects]]
-  digest = "1:a3998b8ea2d61301e5dce8de279e789da031fb36cd98b374e7299591609c34f1"
+  digest = "1:865288d7763eb3e45c4ba1bfde3537f50b30b7b827d32177fd80416e959b6c8d"
   name = "github.com/bradleyfalzon/ghinstallation"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "3f4e9b1898e6b65e31827d5dccb97d91d59feaa3"
-  version = "v0.1.2"
+  revision = "7bdf9f8bf3828df62ed87398508beee1a22a34b1"
+  version = "v0.1.3"
 
 [[projects]]
   digest = "1:7a6852b35eb5bbc184561443762d225116ae630c26a7c4d90546619f1e7d2ad2"
@@ -37,12 +37,12 @@
   version = "v3.2.0"
 
 [[projects]]
-  digest = "1:f4f203acd8b11b8747bdcd91696a01dbc95ccb9e2ca2db6abf81c3a4f5e950ce"
+  digest = "1:91099c6f78b1e7bdf9ed06eb4cb7f017174293a3689d76b995a06f4c8d64a7f0"
   name = "github.com/google/go-github"
   packages = ["github"]
   pruneopts = "NUT"
-  revision = "f55b50f38167644bb7e4be03d9a2bde71d435239"
-  version = "v18.2.0"
+  revision = "9686ff0746200cf521ce225525b421e13b4eac1a"
+  version = "v28.1.1"
 
 [[projects]]
   digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
@@ -61,42 +61,42 @@
   revision = "901d90724c7919163f472a9812253fb26761123d"
 
 [[projects]]
-  digest = "1:b42cde0e1f3c816dd57f57f7bbcf05ca40263ad96f168714c130c611fc0856a6"
+  digest = "1:ed860d2b2c1d066d36a89c982eefc7d019badd534f60e87ab65d3d94f0797ef0"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru",
   ]
   pruneopts = "NUT"
-  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
-  version = "v0.5.0"
+  revision = "7f827b33c0f158ec5dfbba01bb0b14a4541fd81d"
+  version = "v0.5.3"
 
 [[projects]]
   branch = "develop"
-  digest = "1:d1de9d5b676976d6c8044da96e93e314ddbad073d045811de613a308e1afb357"
+  digest = "1:46ddf952419f5c8e972c60ad76794b6af1ac9a3e292908a114605a4be2515cff"
   name = "github.com/palantir/go-baseapp"
   packages = [
     "baseapp",
     "pkg/errfmt",
   ]
   pruneopts = "NUT"
-  revision = "0561b0583746f5a1dfa575bed73ba6d18243d73b"
+  revision = "803ee911331685c77ef3087f8ed2b0feedac2771"
 
 [[projects]]
-  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
+  digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:7c522337040d4ec9a136cd9d64fe4677ee1d3eae4a7f8831c2108f9bec43fa48"
+  digest = "1:45226a195e0a8e8cb87bd1e1689bb85268ad59a423dd95ce4ed2d2381cf2b759"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
+  revision = "cac0b30c2563378d434b5af411844adff8e32960"
 
 [[projects]]
   digest = "1:0975c74a2cd70df6c2ae353c6283a25ce759dda7e1e706e5c07458baf3faca22"
@@ -107,7 +107,7 @@
   version = "v1.2.1"
 
 [[projects]]
-  digest = "1:23e8c184b0a2dff80ce2d0d62bdf433ecf9707eb58361d755cdf2f08c22c2d0c"
+  digest = "1:ad98d64701633b49aa1df6d52a3c6426b2c5ddd6790fffff5f6c9a05b20e1537"
   name = "github.com/rs/zerolog"
   packages = [
     ".",
@@ -117,28 +117,20 @@
     "log",
   ]
   pruneopts = "NUT"
-  revision = "338f9bc14084d22cb8eeacd6492861f8449d715c"
-  version = "v1.9.1"
+  revision = "7592fcbe604741a8d6044390c09d70c01569e1b3"
+  version = "v1.16.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:3d10a3bdabc0890155135c0be1034e56c69ea22239eb8f19a430230c74edad3b"
+  digest = "1:a42ecf585dcd53dbad216f9283092c5de9b25c3e1cf3cae8fb38de64d7061b4e"
   name = "github.com/shurcooL/githubv4"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "51d7b505e2e9434db74794b52222c13253209955"
+  revision = "6d1ea27df5210159a4fb51d926b09feffed1bc77"
 
 [[projects]]
   branch = "master"
-  digest = "1:ddaa79b37808fbd09a1c3f484bba6320c884664dfc25ccc5f2d7d5a82222177c"
-  name = "github.com/shurcooL/go"
-  packages = ["ctxhttp"]
-  pruneopts = "NUT"
-  revision = "9e1955d9fb6e1ee2345ba1f5e71669263e719e27"
-
-[[projects]]
-  branch = "master"
-  digest = "1:95aa903ea7bb8beff197c3770764373d076095408996e39e2206ed9e85ab14bb"
+  digest = "1:ae48f0f40520744c5e6c603b61a16cfe0e4c778360fd53c7c8e2eeaa14b283c6"
   name = "github.com/shurcooL/graphql"
   packages = [
     ".",
@@ -146,7 +138,7 @@
     "internal/jsonutil",
   ]
   pruneopts = "NUT"
-  revision = "e4a3a37e6d42afa87afee2edeeced52300b63893"
+  revision = "d48a9a75455f6af30244670bc0c9d0e38e7392b5"
 
 [[projects]]
   digest = "1:f23222558887a5919f8e9021ecb205395de463f031dd0c049e6e8e547b57c3f4"
@@ -157,7 +149,7 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:1787b9946a55f9ca5908bd65b9dcf6e2649a00991042ed50bb0eee6a26ff0fe7"
+  digest = "1:6fdeb16154fb0202be42be33e6f891dd768fe391dbc23cc8e18599c536e4c37f"
   name = "goji.io"
   packages = [
     ".",
@@ -166,51 +158,63 @@
     "pattern",
   ]
   pruneopts = "NUT"
-  revision = "0d89ff54b2c18c9c4ba530e32496aef902d3c6cd"
-  version = "v2.0"
+  revision = "490b001d03d16a116d7c44d95d216c69a1aae798"
+  version = "v2.0.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:a68068595227881a09dd5961976ddf705c8eea822dcd1c7b57bbb0067335ad32"
+  digest = "1:9ff9e02726d2ea057650cc827f1f808ee3ee15aba08f2d68800aa50d7a4e937a"
   name = "golang.org/x/crypto"
   packages = [
+    "cast5",
     "internal/subtle",
     "nacl/secretbox",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
     "poly1305",
     "salsa20/salsa",
   ]
   pruneopts = "NUT"
-  revision = "e3636079e1a4c1f337f212cc5cd2aca108f6c900"
+  revision = "8986dd9e96cf0a6f74da406c005ba3df38527c04"
 
 [[projects]]
   branch = "master"
-  digest = "1:d6b719875cf8091fbab38527d81d34e71f4521b9ee9ccfbd4a32cff2ac5af96e"
+  digest = "1:7ccb2dbb79f60b4e530c7dc3a0b3681b3869cf7ea91c645735e4dd4e6e3264fd"
   name = "golang.org/x/net"
-  packages = [
-    "context",
-    "context/ctxhttp",
-  ]
+  packages = ["context/ctxhttp"]
   pruneopts = "NUT"
-  revision = "146acd28ed5894421fb5aac80ca93bc1b1f46f87"
+  revision = "fe3aa8a4527195a6057b3fad46619d7d090e99b5"
 
 [[projects]]
   branch = "master"
-  digest = "1:fab6f7f953638242af9ab52d7ab10bcbfd695c09934cac829206732973e94662"
+  digest = "1:f3a2e6d7423b8c19cdb2203cda9672900cc43012ea69f30ff6874dd453f44aec"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "internal",
   ]
   pruneopts = "NUT"
-  revision = "c57b0facaced709681d9f90397429b9430a74754"
+  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
 
 [[projects]]
-  digest = "1:7c95b35057a0ff2e19f707173cc1a947fa43a6eb5c4d300d196ece0334046082"
+  branch = "master"
+  digest = "1:95abab3e07422980e85e253e49eb75c05c1dee6e84b50cb0d3353747ef8099eb"
+  name = "golang.org/x/sys"
+  packages = ["cpu"]
+  pruneopts = "NUT"
+  revision = "f43be2a4598cf3a47be9f94f0c28197ed9eae611"
+
+[[projects]]
+  digest = "1:accc3bfe4e404aa53ac3621470e7cf9fce1efe48f0fabcfe6d12a72579d9d91f"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "f221b8435cfb71e54062f6c6e99e9ade30b124d5"
+  version = "v2.2.4"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,6 +3,10 @@ ignored = [
   "github.com/golang/protobuf/proto"
 ]
 
+[[constraint]]
+name = "github.com/bradleyfalzon/ghinstallation"
+version = "<1.0.0"
+
 [prune]
   non-go = true
   go-tests = true


### PR DESCRIPTION
As of 1.0.0, this library includes a breaking API change and appears to require that we adopt modules to be compatible with the go-github imports.

First reported in #28, but relates to #9 as well, for module support.