### PR TITLE
Add support for asynchronous dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ middleware.
 | `github.rate.limit[installation:<id>]` | `gauge` | the maximum number of requests permitted to make per hour, tagged with the installation id |
 | `github.rate.remaining[installation:<id>]` | `gauge` | the number of requests remaining in the current rate limit window, tagged with the installation id |
 
-If using [asynchronous dispatch][#asynchronous-dispatch] and the `githubapp.WithSchedulingMetrics` option
+If using [asynchronous dispatch](#asynchronous-dispatch) and the `githubapp.WithSchedulingMetrics` option
 is set, these metrics are emitted:
 
 | metric name | type | definition |

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ will miss out on the free built-in support.
 GitHub imposes timeouts on webhook delivery responses. If an application does
 not respond in time, GitHub closes the connection and marks the delivery as
 failed. `go-githubapp` optionally supports asynchronous dispatch to help solve
-this problem. When enabled, the event dispatch sends a response to GitHub after
+this problem. When enabled, the event dispatcher sends a response to GitHub after
 validating the payload and then runs the event handler in a separate goroutine.
 
 To enable, select an appropriate _scheduler_ and configure the event dispatcher

--- a/githubapp/dispatcher.go
+++ b/githubapp/dispatcher.go
@@ -188,8 +188,7 @@ func (d *eventDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	handler, ok := d.handlerMap[eventType]
 	if ok {
-		if err := d.scheduler.Schedule(Dispatch{
-			Ctx:        ctx,
+		if err := d.scheduler.Schedule(ctx, Dispatch{
 			Handler:    handler,
 			EventType:  eventType,
 			DeliveryID: deliveryID,

--- a/githubapp/dispatcher.go
+++ b/githubapp/dispatcher.go
@@ -54,7 +54,7 @@ type ResponseCallback func(w http.ResponseWriter, r *http.Request, event string,
 // DispatcherOption configures properties of an event dispatcher.
 type DispatcherOption func(*eventDispatcher)
 
-// WithErrorCallback sets the error callback for an event dispatcher.
+// WithErrorCallback sets the error callback for a dispatcher.
 func WithErrorCallback(onError ErrorCallback) DispatcherOption {
 	return func(d *eventDispatcher) {
 		if onError != nil {
@@ -68,6 +68,20 @@ func WithResponseCallback(onResponse ResponseCallback) DispatcherOption {
 	return func(d *eventDispatcher) {
 		if onResponse != nil {
 			d.onResponse = onResponse
+		}
+	}
+}
+
+// WithScheduler set the scheduler used to process events. Setting a
+// non-default scheduler can enable asynchronous processing. When a scheduler
+// is asynchronous, the dispatcher validatates event payloads, queues valid
+// events for handling, and then responds to GitHub without waiting for the
+// handler to complete.  This is useful when handlers may take longer than
+// GitHub's timeout for webhook deliveries.
+func WithScheduler(s Scheduler) DispatcherOption {
+	return func(d *eventDispatcher) {
+		if s != nil {
+			d.scheduler = s
 		}
 	}
 }
@@ -88,6 +102,7 @@ type eventDispatcher struct {
 	handlerMap map[string]EventHandler
 	secret     string
 
+	scheduler  Scheduler
 	onError    ErrorCallback
 	onResponse ResponseCallback
 }
@@ -118,6 +133,7 @@ func NewEventDispatcher(handlers []EventHandler, secret string, opts ...Dispatch
 	d := &eventDispatcher{
 		handlerMap: handlerMap,
 		secret:     secret,
+		scheduler:  DefaultScheduler(),
 		onError:    DefaultErrorCallback,
 		onResponse: DefaultResponseCallback,
 	}
@@ -172,7 +188,13 @@ func (d *eventDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	handler, ok := d.handlerMap[eventType]
 	if ok {
-		if err := handler.Handle(ctx, eventType, deliveryID, payloadBytes); err != nil {
+		if err := d.scheduler.Schedule(Dispatch{
+			Ctx:        ctx,
+			Handler:    handler,
+			EventType:  eventType,
+			DeliveryID: deliveryID,
+			Payload:    payloadBytes,
+		}); err != nil {
 			d.onError(w, r, err)
 			return
 		}
@@ -184,13 +206,19 @@ func (d *eventDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func DefaultErrorCallback(w http.ResponseWriter, r *http.Request, err error) {
 	logger := zerolog.Ctx(r.Context())
 
-	if ve, ok := err.(ValidationError); ok {
+	var ve ValidationError
+	if errors.As(err, &ve) {
 		logger.Warn().Err(ve.Cause).Msgf("Received invalid webhook headers or payload")
 		http.Error(w, "Invalid webhook headers or payload", http.StatusBadRequest)
 		return
 	}
+	if errors.Is(err, ErrCapacityExceeded) {
+		logger.Warn().Msg("Dropping webhook event due to over-capacity scheduler")
+		http.Error(w, "No capacity available to processes this event", http.StatusServiceUnavailable)
+		return
+	}
 
-	logger.Error().Err(err).Msg("Unexpected error handling webhook request")
+	logger.Error().Err(err).Msg("Unexpected error handling webhook")
 	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 }
 

--- a/githubapp/dispatcher.go
+++ b/githubapp/dispatcher.go
@@ -72,7 +72,7 @@ func WithResponseCallback(onResponse ResponseCallback) DispatcherOption {
 	}
 }
 
-// WithScheduler set the scheduler used to process events. Setting a
+// WithScheduler sets the scheduler used to process events. Setting a
 // non-default scheduler can enable asynchronous processing. When a scheduler
 // is asynchronous, the dispatcher validatates event payloads, queues valid
 // events for handling, and then responds to GitHub without waiting for the

--- a/githubapp/scheduler.go
+++ b/githubapp/scheduler.go
@@ -1,0 +1,238 @@
+// Copyright 2020 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubapp
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/pkg/errors"
+	"github.com/rcrowley/go-metrics"
+	"github.com/rs/zerolog"
+)
+
+const (
+	MetricsKeyQueueLength   = "github.event.queued"
+	MetricsKeyActiveWorkers = "github.event.workers"
+)
+
+var (
+	ErrCapacityExceeded = errors.New("scheduler: capacity exceeded")
+)
+
+// Dispatch is a webhook payload and the handler that handles it.
+type Dispatch struct {
+	Handler EventHandler
+	Ctx     context.Context
+
+	EventType  string
+	DeliveryID string
+	Payload    []byte
+}
+
+// Execute calls the Dispatch's handler with the stored arguments.
+func (d Dispatch) Execute() error {
+	return d.Handler.Handle(d.Ctx, d.EventType, d.DeliveryID, d.Payload)
+}
+
+// AsyncErrorCallback is called by an asynchronous scheduler when an event
+// handler returns an error. The error from the handler is passed directly as
+// the final argument.
+type AsyncErrorCallback func(ctx context.Context, err error)
+
+// DefaultAsyncErrorCallback logs errors.
+func DefaultAsyncErrorCallback(ctx context.Context, err error) {
+	zerolog.Ctx(ctx).Error().Err(err).Msg("Unexpected error handling webhook")
+}
+
+// ContextDeriver creates a new independent context from a request's context.
+// The new context must be based on context.Background(), not the input.
+type ContextDeriver func(context.Context) context.Context
+
+// DefaultContextDeriver copies the logger from the request's context to a new
+// context.
+func DefaultContextDeriver(ctx context.Context) context.Context {
+	newCtx := context.Background()
+
+	// this value is always unused by async schedulers, but is set for
+	// compatibility with existing handlers that call SetResponder
+	newCtx = InitializeResponder(newCtx)
+
+	return zerolog.Ctx(ctx).WithContext(newCtx)
+}
+
+// Scheduler is a strategy for executing event handlers.
+//
+// The Schedule method takes a Dispatch and executes it by calling the handler
+// for the payload. The execution may be asynchronous, but the scheduler must
+// create a new context in this case. The dispatcher waits for Schedule to
+// return before responding to GitHub, so asynchronous schedulers should only
+// return errors that happen during scheduling, not during execution.
+//
+// Schedule may return ErrCapacityExceeded if it cannot schedule or queue new
+// events at the time of the call.
+type Scheduler interface {
+	Schedule(d Dispatch) error
+}
+
+// SchedulerOption configures properties of a scheduler.
+type SchedulerOption func(*scheduler)
+
+// WithAsyncErrorCallback sets the error callback for an asynchronous
+// scheduler. If not set, the scheduler uses DefaultAsyncErrorCallback.
+func WithAsyncErrorCallback(onError AsyncErrorCallback) SchedulerOption {
+	return func(s *scheduler) {
+		if onError != nil {
+			s.onError = onError
+		}
+	}
+}
+
+// WithContextDeriver sets the context deriver for an asynchronous scheduler.
+// If not set, the scheduler uses DefaultContextDeriver.
+func WithContextDeriver(deriver ContextDeriver) SchedulerOption {
+	return func(s *scheduler) {
+		if deriver != nil {
+			s.deriver = deriver
+		}
+	}
+}
+
+// WithSchedulingMetrics enables metrics reporting for schedulers.
+func WithSchedulingMetrics(r metrics.Registry) SchedulerOption {
+	return func(s *scheduler) {
+		metrics.NewRegisteredFunctionalGauge(MetricsKeyQueueLength, r, func() int64 {
+			return int64(len(s.queue))
+		})
+		metrics.NewRegisteredFunctionalGauge(MetricsKeyActiveWorkers, r, func() int64 {
+			return atomic.LoadInt64(&s.activeWorkers)
+		})
+	}
+}
+
+// core functionality and options for (async) schedulers
+type scheduler struct {
+	onError AsyncErrorCallback
+	deriver ContextDeriver
+
+	activeWorkers int64
+	queue         chan Dispatch
+}
+
+func (s *scheduler) safeExecute(d Dispatch) {
+	var err error
+	defer func() {
+		if r := recover(); r != nil {
+			if rerr, ok := r.(error); ok {
+				err = rerr
+			} else {
+				err = fmt.Errorf("%v", r)
+			}
+		}
+		if err != nil && s.onError != nil {
+			s.onError(d.Ctx, err)
+		}
+		atomic.AddInt64(&s.activeWorkers, -1)
+	}()
+
+	atomic.AddInt64(&s.activeWorkers, 1)
+	if s.deriver != nil {
+		d.Ctx = s.deriver(d.Ctx)
+	}
+	err = d.Execute()
+}
+
+// DefaultScheduler returns a scheduler that executes handlers in the go
+// routine of the caller and returns any error.
+func DefaultScheduler() Scheduler {
+	return &defaultScheduler{}
+}
+
+type defaultScheduler struct{}
+
+func (s *defaultScheduler) Schedule(d Dispatch) error {
+	return d.Execute()
+}
+
+// AsyncScheduler returns a scheduler that executes handlers in new goroutines.
+// Goroutines are not reused and there is no limit on the number created.
+func AsyncScheduler(opts ...SchedulerOption) Scheduler {
+	s := &asyncScheduler{
+		scheduler: scheduler{
+			deriver: DefaultContextDeriver,
+			onError: DefaultAsyncErrorCallback,
+		},
+	}
+	for _, opt := range opts {
+		opt(&s.scheduler)
+	}
+	return s
+}
+
+type asyncScheduler struct {
+	scheduler
+}
+
+func (s *asyncScheduler) Schedule(d Dispatch) error {
+	go s.safeExecute(d)
+	return nil
+}
+
+// QueueAsyncScheduler returns a scheduler that executes handlers in a fixed
+// number of worker goroutines. If no workers are available, events queue until
+// the queue is full.
+func QueueAsyncScheduler(queueSize int, workers int, opts ...SchedulerOption) Scheduler {
+	if queueSize < 0 {
+		panic("NewQueueAsyncScheduler: queue size must be non-negative")
+	}
+	if workers < 1 {
+		panic("NewQueueAsyncScheduler: worker count must be positive")
+	}
+
+	s := &queueScheduler{
+		scheduler: scheduler{
+			deriver: DefaultContextDeriver,
+			onError: DefaultAsyncErrorCallback,
+			queue:   make(chan Dispatch, queueSize),
+		},
+	}
+	for _, opt := range opts {
+		opt(&s.scheduler)
+	}
+
+	for i := 0; i < workers; i++ {
+		go func() {
+			for d := range s.queue {
+				s.safeExecute(d)
+			}
+		}()
+	}
+
+	return s
+}
+
+type queueScheduler struct {
+	scheduler
+}
+
+func (s *queueScheduler) Schedule(d Dispatch) error {
+	select {
+	case s.queue <- d:
+	default:
+		return ErrCapacityExceeded
+	}
+	return nil
+}

--- a/githubapp/scheduler.go
+++ b/githubapp/scheduler.go
@@ -200,10 +200,10 @@ func (s *asyncScheduler) Schedule(ctx context.Context, d Dispatch) error {
 // the queue is full.
 func QueueAsyncScheduler(queueSize int, workers int, opts ...SchedulerOption) Scheduler {
 	if queueSize < 0 {
-		panic("NewQueueAsyncScheduler: queue size must be non-negative")
+		panic("QueueAsyncScheduler: queue size must be non-negative")
 	}
 	if workers < 1 {
-		panic("NewQueueAsyncScheduler: worker count must be positive")
+		panic("QueueAsyncScheduler: worker count must be positive")
 	}
 
 	s := &queueScheduler{

--- a/githubapp/scheduler_test.go
+++ b/githubapp/scheduler_test.go
@@ -45,8 +45,7 @@ func TestAsyncScheduler(t *testing.T) {
 		s := AsyncScheduler()
 		h := AsyncHandler{Called: make(chan bool, 1)}
 
-		if err := s.Schedule(Dispatch{
-			Ctx:     context.Background(),
+		if err := s.Schedule(context.Background(), Dispatch{
 			Handler: &h,
 		}); err != nil {
 			t.Fatalf("unexpected error scheduling dispatch: %v", err)
@@ -72,8 +71,7 @@ func TestAsyncScheduler(t *testing.T) {
 		s := AsyncScheduler(WithAsyncErrorCallback(cb))
 		h := AsyncHandler{Called: make(chan bool, 1), Error: errors.New("handler error")}
 
-		if err := s.Schedule(Dispatch{
-			Ctx:     context.Background(),
+		if err := s.Schedule(context.Background(), Dispatch{
 			Handler: &h,
 		}); err != nil {
 			t.Fatalf("unexpected error scheduling dispatch: %v", err)
@@ -98,8 +96,7 @@ func TestQueueAsyncScheduler(t *testing.T) {
 		s := QueueAsyncScheduler(1, 1)
 		h := AsyncHandler{Called: make(chan bool, 1)}
 
-		if err := s.Schedule(Dispatch{
-			Ctx:     context.Background(),
+		if err := s.Schedule(context.Background(), Dispatch{
 			Handler: &h,
 		}); err != nil {
 			t.Fatalf("unexpected error scheduling dispatch: %v", err)
@@ -125,8 +122,7 @@ func TestQueueAsyncScheduler(t *testing.T) {
 		s := QueueAsyncScheduler(1, 1, WithAsyncErrorCallback(cb))
 		h := AsyncHandler{Called: make(chan bool, 1), Error: errors.New("handler error")}
 
-		if err := s.Schedule(Dispatch{
-			Ctx:     context.Background(),
+		if err := s.Schedule(context.Background(), Dispatch{
 			Handler: &h,
 		}); err != nil {
 			t.Fatalf("unexpected error scheduling dispatch: %v", err)
@@ -146,15 +142,15 @@ func TestQueueAsyncScheduler(t *testing.T) {
 	t.Run("rejectEventsWhenFull", func(t *testing.T) {
 		s := QueueAsyncScheduler(1, 1)
 		h := AsyncHandler{Block: make(chan struct{}), Called: make(chan bool, 1)}
+		ctx := context.Background()
 		d := Dispatch{
-			Ctx:     context.Background(),
 			Handler: &h,
 		}
 
-		if err := s.Schedule(d); err != nil {
+		if err := s.Schedule(ctx, d); err != nil {
 			t.Fatalf("unexpected error scheduling first dispatch: %v", err)
 		}
-		if err := s.Schedule(d); err != ErrCapacityExceeded {
+		if err := s.Schedule(ctx, d); err != ErrCapacityExceeded {
 			t.Fatalf("expected ErrCapacityExceeded, but got: %v", err)
 		}
 	})

--- a/githubapp/scheduler_test.go
+++ b/githubapp/scheduler_test.go
@@ -1,0 +1,161 @@
+// Copyright 2020 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type AsyncHandler struct {
+	Block  chan struct{}
+	Called chan bool
+	Error  error
+}
+
+func (h *AsyncHandler) Handles() []string { return []string{"ping"} }
+
+func (h *AsyncHandler) Handle(ctx context.Context, eventType, id string, payload []byte) error {
+	if h.Block != nil {
+		<-h.Block
+	}
+	h.Called <- true
+	return h.Error
+}
+
+func TestAsyncScheduler(t *testing.T) {
+	const timeout = 100 * time.Millisecond
+
+	t.Run("callsHandler", func(t *testing.T) {
+		s := AsyncScheduler()
+		h := AsyncHandler{Called: make(chan bool, 1)}
+
+		if err := s.Schedule(Dispatch{
+			Ctx:     context.Background(),
+			Handler: &h,
+		}); err != nil {
+			t.Fatalf("unexpected error scheduling dispatch: %v", err)
+		}
+
+		called := false
+		select {
+		case called = <-h.Called:
+		case <-time.After(timeout):
+		}
+
+		if !called {
+			t.Fatalf("handler was not called after %v", timeout)
+		}
+	})
+
+	t.Run("errorCallback", func(t *testing.T) {
+		errc := make(chan error, 1)
+		cb := func(ctx context.Context, err error) {
+			errc <- err
+		}
+
+		s := AsyncScheduler(WithAsyncErrorCallback(cb))
+		h := AsyncHandler{Called: make(chan bool, 1), Error: errors.New("handler error")}
+
+		if err := s.Schedule(Dispatch{
+			Ctx:     context.Background(),
+			Handler: &h,
+		}); err != nil {
+			t.Fatalf("unexpected error scheduling dispatch: %v", err)
+		}
+
+		var herr error
+		select {
+		case herr = <-errc:
+		case <-time.After(timeout):
+		}
+
+		if herr == nil {
+			t.Fatalf("handler did not report an error after %v", timeout)
+		}
+	})
+}
+
+func TestQueueAsyncScheduler(t *testing.T) {
+	const timeout = 100 * time.Millisecond
+
+	t.Run("callsHandler", func(t *testing.T) {
+		s := QueueAsyncScheduler(1, 1)
+		h := AsyncHandler{Called: make(chan bool, 1)}
+
+		if err := s.Schedule(Dispatch{
+			Ctx:     context.Background(),
+			Handler: &h,
+		}); err != nil {
+			t.Fatalf("unexpected error scheduling dispatch: %v", err)
+		}
+
+		called := false
+		select {
+		case called = <-h.Called:
+		case <-time.After(timeout):
+		}
+
+		if !called {
+			t.Fatalf("handler was not called after %v", timeout)
+		}
+	})
+
+	t.Run("errorCallback", func(t *testing.T) {
+		errc := make(chan error, 1)
+		cb := func(ctx context.Context, err error) {
+			errc <- err
+		}
+
+		s := QueueAsyncScheduler(1, 1, WithAsyncErrorCallback(cb))
+		h := AsyncHandler{Called: make(chan bool, 1), Error: errors.New("handler error")}
+
+		if err := s.Schedule(Dispatch{
+			Ctx:     context.Background(),
+			Handler: &h,
+		}); err != nil {
+			t.Fatalf("unexpected error scheduling dispatch: %v", err)
+		}
+
+		var herr error
+		select {
+		case herr = <-errc:
+		case <-time.After(timeout):
+		}
+
+		if herr == nil {
+			t.Fatalf("handler did not report an error after %v", timeout)
+		}
+	})
+
+	t.Run("rejectEventsWhenFull", func(t *testing.T) {
+		s := QueueAsyncScheduler(1, 1)
+		h := AsyncHandler{Block: make(chan struct{}), Called: make(chan bool, 1)}
+		d := Dispatch{
+			Ctx:     context.Background(),
+			Handler: &h,
+		}
+
+		if err := s.Schedule(d); err != nil {
+			t.Fatalf("unexpected error scheduling first dispatch: %v", err)
+		}
+		if err := s.Schedule(d); err != ErrCapacityExceeded {
+			t.Fatalf("expected ErrCapacityExceeded, but got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Introduce a configurable scheduler option for NewEventDispatcher and add
two asynchronous schedulers, one that is unlimited and one that uses a
bounded queue and a fixed number of workers.

For many applications, switching to asynchronous handling will be as
easy as adding this new option when creating the event dispatcher. Other
application will need to provide a custom ContextDeriver to copy values
from the request context into the detached handler context.

As a result of error handling code introduced as part of this change,
go-githubapp now requires at least Go 1.13.