### PR TITLE
add ability to configure Timeout for http.Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ distinct clients:
 These are provided when calling `githubapp.NewClientCreator`:
 
 - `githubapp.WithClientUserAgent` sets a `User-Agent` string for all clients
+- `githubapp.WithClientTimeout` sets a timeout for requests made by all clients
 - `githubapp.WithClientCaching` enables response caching for all v3 (REST) clients.
    The cache can be configured to always validate responses or to respect
    the cache headers returned by GitHub. Re-validation is useful if data

--- a/example/main.go
+++ b/example/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/gregjones/httpcache"
 	"github.com/palantir/go-baseapp/baseapp"
@@ -43,6 +44,7 @@ func main() {
 	cc, err := githubapp.NewDefaultCachingClientCreator(
 		config.Github,
 		githubapp.WithClientUserAgent("example-app/1.0.0"),
+		githubapp.WithClientTimeout(3*time.Second),
 		githubapp.WithClientCaching(false, func() httpcache.Cache { return httpcache.NewMemoryCache() }),
 		githubapp.WithClientMiddleware(
 			githubapp.ClientMetrics(server.Registry()),

--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/bradleyfalzon/ghinstallation"
 	"github.com/google/go-github/v32/github"
@@ -127,6 +128,7 @@ type clientCreator struct {
 	middleware     []ClientMiddleware
 	cacheFunc      func() httpcache.Cache
 	alwaysValidate bool
+	timeout        time.Duration
 }
 
 var _ ClientCreator = &clientCreator{}
@@ -250,7 +252,10 @@ func (c *clientCreator) NewTokenV4Client(token string) (*githubv4.Client, error)
 }
 
 func (c *clientCreator) newHttpClient() *http.Client {
-	return &http.Client{Transport: http.DefaultTransport}
+	return &http.Client{
+		Transport: http.DefaultTransport,
+		Timeout:   c.timeout,
+	}
 }
 
 func (c *clientCreator) newClient(base *http.Client, middleware []ClientMiddleware, details string, installID int64) (*github.Client, error) {

--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -158,8 +158,7 @@ func WithClientCaching(alwaysValidate bool, cache func() httpcache.Cache) Client
 	}
 }
 
-// WithClientTimeout sets the timeout on http.Client for all created clients. This will set a timeout
-// on all requests made by the client.
+// WithClientTimeout sets a request timeout for requests made by all created clients.
 func WithClientTimeout(timeout time.Duration) ClientOption {
 	return func(c *clientCreator) {
 		c.timeout = timeout

--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -164,7 +164,7 @@ func WithClientMiddleware(middleware ...ClientMiddleware) ClientOption {
 }
 
 func (c *clientCreator) NewAppClient() (*github.Client, error) {
-	base := &http.Client{Transport: http.DefaultTransport}
+	base := c.newHttpClient()
 	installation, transportError := newAppInstallation(c.integrationID, c.privKeyBytes, c.v3BaseURL)
 
 	middleware := []ClientMiddleware{installation}
@@ -183,7 +183,7 @@ func (c *clientCreator) NewAppClient() (*github.Client, error) {
 }
 
 func (c *clientCreator) NewAppV4Client() (*githubv4.Client, error) {
-	base := &http.Client{Transport: http.DefaultTransport}
+	base := c.newHttpClient()
 	installation, transportError := newAppInstallation(c.integrationID, c.privKeyBytes, c.v3BaseURL)
 
 	// The v4 API primarily uses POST requests (except for introspection queries)
@@ -201,7 +201,7 @@ func (c *clientCreator) NewAppV4Client() (*githubv4.Client, error) {
 }
 
 func (c *clientCreator) NewInstallationClient(installationID int64) (*github.Client, error) {
-	base := &http.Client{Transport: http.DefaultTransport}
+	base := c.newHttpClient()
 	installation, transportError := newInstallation(c.integrationID, installationID, c.privKeyBytes, c.v3BaseURL)
 
 	middleware := []ClientMiddleware{installation}
@@ -220,7 +220,7 @@ func (c *clientCreator) NewInstallationClient(installationID int64) (*github.Cli
 }
 
 func (c *clientCreator) NewInstallationV4Client(installationID int64) (*githubv4.Client, error) {
-	base := &http.Client{Transport: http.DefaultTransport}
+	base := c.newHttpClient()
 	installation, transportError := newInstallation(c.integrationID, installationID, c.privKeyBytes, c.v3BaseURL)
 
 	// The v4 API primarily uses POST requests (except for introspection queries)
@@ -247,6 +247,10 @@ func (c *clientCreator) NewTokenV4Client(token string) (*githubv4.Client, error)
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(context.Background(), ts)
 	return c.newV4Client(tc, nil, "oauth token")
+}
+
+func (c *clientCreator) newHttpClient() *http.Client {
+	return &http.Client{Transport: http.DefaultTransport}
 }
 
 func (c *clientCreator) newClient(base *http.Client, middleware []ClientMiddleware, details string, installID int64) (*github.Client, error) {

--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -158,6 +158,14 @@ func WithClientCaching(alwaysValidate bool, cache func() httpcache.Cache) Client
 	}
 }
 
+// WithClientTimeout sets the timeout on http.Client for all created clients. This will set a timeout
+// on all requests made by the client.
+func WithClientTimeout(timeout time.Duration) ClientOption {
+	return func(c *clientCreator) {
+		c.timeout = timeout
+	}
+}
+
 // WithClientMiddleware adds middleware that is applied to all created clients.
 func WithClientMiddleware(middleware ...ClientMiddleware) ClientOption {
 	return func(c *clientCreator) {

--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -174,7 +174,7 @@ func WithClientMiddleware(middleware ...ClientMiddleware) ClientOption {
 }
 
 func (c *clientCreator) NewAppClient() (*github.Client, error) {
-	base := c.newHttpClient()
+	base := c.newHTTPClient()
 	installation, transportError := newAppInstallation(c.integrationID, c.privKeyBytes, c.v3BaseURL)
 
 	middleware := []ClientMiddleware{installation}
@@ -193,7 +193,7 @@ func (c *clientCreator) NewAppClient() (*github.Client, error) {
 }
 
 func (c *clientCreator) NewAppV4Client() (*githubv4.Client, error) {
-	base := c.newHttpClient()
+	base := c.newHTTPClient()
 	installation, transportError := newAppInstallation(c.integrationID, c.privKeyBytes, c.v3BaseURL)
 
 	// The v4 API primarily uses POST requests (except for introspection queries)
@@ -211,7 +211,7 @@ func (c *clientCreator) NewAppV4Client() (*githubv4.Client, error) {
 }
 
 func (c *clientCreator) NewInstallationClient(installationID int64) (*github.Client, error) {
-	base := c.newHttpClient()
+	base := c.newHTTPClient()
 	installation, transportError := newInstallation(c.integrationID, installationID, c.privKeyBytes, c.v3BaseURL)
 
 	middleware := []ClientMiddleware{installation}
@@ -230,7 +230,7 @@ func (c *clientCreator) NewInstallationClient(installationID int64) (*github.Cli
 }
 
 func (c *clientCreator) NewInstallationV4Client(installationID int64) (*githubv4.Client, error) {
-	base := c.newHttpClient()
+	base := c.newHTTPClient()
 	installation, transportError := newInstallation(c.integrationID, installationID, c.privKeyBytes, c.v3BaseURL)
 
 	// The v4 API primarily uses POST requests (except for introspection queries)
@@ -259,7 +259,7 @@ func (c *clientCreator) NewTokenV4Client(token string) (*githubv4.Client, error)
 	return c.newV4Client(tc, nil, "oauth token")
 }
 
-func (c *clientCreator) newHttpClient() *http.Client {
+func (c *clientCreator) newHTTPClient() *http.Client {
 	return &http.Client{
 		Transport: http.DefaultTransport,
 		Timeout:   c.timeout,


### PR DESCRIPTION
Adds the ability to configure the `http.Client`'s Timeout field, which is used to set a timeout for requests made by the client.