### PR TITLE
Add event.dropped and event.age metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ middleware.
 | `github.rate.limit[installation:<id>]` | `gauge` | the maximum number of requests permitted to make per hour, tagged with the installation id |
 | `github.rate.remaining[installation:<id>]` | `gauge` | the number of requests remaining in the current rate limit window, tagged with the installation id |
 
-If using [asynchronous dispatch](#asynchronous-dispatch) and the `githubapp.WithSchedulingMetrics` option
-is set, these metrics are emitted:
+When using [asynchronous dispatch](#asynchronous-dispatch), the
+`githubapp.WithSchedulingMetrics` option emits the following metrics:
 
 | metric name | type | definition |
 | ----------- | ---- | ---------- |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ logic of your application.
 * [Asynchronous Dispatch](#asynchronous-dispatch)
 * [Structured Logging](#structured-logging)
 * [GitHub Clients](#github-clients)
-  + [Metrics](#metrics)
+* [Metrics](#metrics)
 * [Background Jobs and Multi-Organization Operations](#background-jobs-and-multi-organization-operations)
 * [OAuth2](#oauth2)
 * [Stability and Versioning Guarantees](#stability-and-versioning-guarantees)
@@ -203,7 +203,7 @@ baseHandler, err := githubapp.NewDefaultCachingClientCreator(
 )
 ```
 
-### Metrics
+## Metrics
 
 `go-githubapp` uses [rcrowley/go-metrics][] to provide metrics. GitHub clients
 emit the metrics below if configured with the `githubapp.ClientMetrics`
@@ -227,6 +227,8 @@ is set, these metrics are emitted:
 | ----------- | ---- | ---------- |
 | `github.event.queue` | `gauge` | the number of queued unprocessed event |
 | `github.event.workers` | `gauge` | the number of workers actively processing events |
+| `github.event.dropped` | `counter` | the number events dropped due to limited queue capacity |
+| `github.event.age` | `histogram` | the age (queue time) in milliseconds of events at processing time |
 
 Note that metrics need to be published in order to be useful. Several
 [publishing options][] are available or you can implement your own.

--- a/githubapp/scheduler.go
+++ b/githubapp/scheduler.go
@@ -32,6 +32,12 @@ const (
 	MetricsKeyDroppedEvents = "github.event.dropped"
 )
 
+const (
+	// values from metrics.NewTimer, which match those used by UNIX load averages
+	histogramReservoirSize = 1028
+	histogramAlpha         = 0.015
+)
+
 var (
 	ErrCapacityExceeded = errors.New("scheduler: capacity exceeded")
 )
@@ -123,8 +129,8 @@ func WithSchedulingMetrics(r metrics.Registry) SchedulerOption {
 			return atomic.LoadInt64(&s.activeWorkers)
 		})
 
-		// use sample values from metrics.NewTimer which match those used by UNIX load averages
-		s.eventAge = metrics.NewRegisteredHistogram(MetricsKeyEventAge, r, metrics.NewExpDecaySample(1028, 0.015))
+		sample := metrics.NewExpDecaySample(histogramReservoirSize, histogramAlpha)
+		s.eventAge = metrics.NewRegisteredHistogram(MetricsKeyEventAge, r, sample)
 		s.dropped = metrics.NewRegisteredCounter(MetricsKeyDroppedEvents, r)
 	}
 }


### PR DESCRIPTION
These provide more insight into the queued asynchronous scheduler.

Closes #42.