### PR TITLE
Add error callbacks that emit metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,11 @@ baseHandler, err := githubapp.NewDefaultCachingClientCreator(
 
 ### Metrics
 
-`go-githubapp` uses [rcrowley/go-metrics][] to provide metrics. GitHub clients
-emit the metrics below if configured with the `githubapp.ClientMetrics`
-middleware.
+`go-githubapp` uses [rcrowley/go-metrics][] to provide metrics. Metrics are
+optional and disabled by default.
+
+GitHub clients emit the following metrics when configured with the
+`githubapp.ClientMetrics` middleware:
 
 | metric name | type | definition |
 | ----------- | ---- | ---------- |
@@ -227,6 +229,13 @@ is set, these metrics are emitted:
 | ----------- | ---- | ---------- |
 | `github.event.queue` | `gauge` | the number of queued unprocessed event |
 | `github.event.workers` | `gauge` | the number of workers actively processing events |
+
+The `MetricsErrorCallback` and `MetricsAsyncErrorCallback` error callbacks for
+the event dispatcher and asynchronous schedulers emit the following metrics:
+
+| metric name | type | definition |
+| ----------- | ---- | ---------- |
+| `github.handler.error[event:<type>]` | `counter` | the number of processing errors, tagged with the GitHub event type |
 
 Note that metrics need to be published in order to be useful. Several
 [publishing options][] are available or you can implement your own.

--- a/githubapp/errors.go
+++ b/githubapp/errors.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubapp
+
+import (
+	"fmt"
+
+	"github.com/rcrowley/go-metrics"
+)
+
+const (
+	MetricsKeyHandlerError = "github.handler.error"
+)
+
+func errorCounter(r metrics.Registry, event string) metrics.Counter {
+	if r == nil {
+		return metrics.NilCounter{}
+	}
+
+	key := MetricsKeyHandlerError
+	if event != "" {
+		key = fmt.Sprintf("%s[event:%s]", key, event)
+	}
+	return metrics.GetOrRegisterCounter(key, r)
+}

--- a/githubapp/scheduler_test.go
+++ b/githubapp/scheduler_test.go
@@ -64,7 +64,7 @@ func TestAsyncScheduler(t *testing.T) {
 
 	t.Run("errorCallback", func(t *testing.T) {
 		errc := make(chan error, 1)
-		cb := func(ctx context.Context, err error) {
+		cb := func(ctx context.Context, d Dispatch, err error) {
 			errc <- err
 		}
 
@@ -115,7 +115,7 @@ func TestQueueAsyncScheduler(t *testing.T) {
 
 	t.Run("errorCallback", func(t *testing.T) {
 		errc := make(chan error, 1)
-		cb := func(ctx context.Context, err error) {
+		cb := func(ctx context.Context, d Dispatch, err error) {
 			errc <- err
 		}
 


### PR DESCRIPTION
These are non-default because they require a metrics registry, but the
default handlers are now implemented by passing a nil registry to the
metric version.

Note that this contains an API break in the AsyncErrorCallback type, but
I don't expect there to be many (any?) custom implementations.

Closes #51.