### PR TITLE
Enable caching middleware for token client

### DIFF
--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -249,12 +249,20 @@ func (c *clientCreator) NewInstallationV4Client(installationID int64) (*githubv4
 func (c *clientCreator) NewTokenClient(token string) (*github.Client, error) {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(context.Background(), ts)
-	return c.newClient(tc, nil, "oauth token", 0)
+
+	middleware := []ClientMiddleware{}
+	if c.cacheFunc != nil {
+		middleware = append(middleware, cache(c.cacheFunc), cacheControl(c.alwaysValidate))
+	}
+
+	return c.newClient(tc, middleware, "oauth token", 0)
 }
 
 func (c *clientCreator) NewTokenV4Client(token string) (*githubv4.Client, error) {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(context.Background(), ts)
+	// The v4 API primarily uses POST requests (except for introspection queries)
+	// which we cannot cache, so don't construct the middleware
 	return c.newV4Client(tc, nil, "oauth token")
 }
 


### PR DESCRIPTION
## Before this PR

We did not enable client caching when creating a token client.

## After this PR

Enable caching middleware for token client when the client creator is configured with caching.
This is analogue to how we enable caching for the other clients: https://github.com/palantir/go-githubapp/blob/d8a2c922f40024065fc18de91417648923111f10/githubapp/client_creator.go#L179-L182