### PR TITLE
Remove `public_url` from example configuration

### DIFF
--- a/example/config.yml
+++ b/example/config.yml
@@ -1,7 +1,6 @@
 server:
   address: "127.0.0.1"
   port: 8080
-  public_url: "http://localhost:8080"
 
 github:
   v3_api_url: "https://api.github.com/"


### PR DESCRIPTION
The key `server.public_url` is not in use in any of this application.
It is removed for simplicity reasons.