### PR TITLE
Support remote references in default config

### DIFF
--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -242,6 +242,18 @@ func (ld *Loader) loadDefaultConfig(ctx context.Context, client *github.Client, 
 			continue
 		}
 
+		// if remote refs are enabled, see if the file is a remote reference
+		if ld.parser != nil {
+			remote, err := ld.parser(p, content)
+			if err != nil {
+				return c, err
+			}
+			if remote != nil {
+				logger.Debug().Msgf("Found remote default configuration at %s in %s", p, c.Source)
+				return ld.loadRemoteConfig(ctx, client, *remote, c)
+			}
+		}
+
 		// non-remote content found, don't try any other paths
 		logger.Debug().Msgf("Found default configuration at %s in %s", c.Path, c.Source)
 		c.Content = content

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -93,6 +93,19 @@ func TestLoadConfig(t *testing.T) {
 				Path:    "test-app.yml",
 			},
 		},
+		"defaultConfigRemoteReference": {
+			Paths: []string{".github-remote/test-app.yml"},
+			Options: []Option{
+				WithOwnerDefault(".github-remote", []string{"test-app.yml"}),
+			},
+			Repo: "default-config-remote-ref",
+			Expected: Config{
+				Content:  []byte("message: hello\n"),
+				Source:   "remote/config@develop",
+				Path:     "config/test-app.yml",
+				IsRemote: true,
+			},
+		},
 	}
 
 	ctx := context.Background()
@@ -147,6 +160,10 @@ func makeTestClient() *github.Client {
 		"/repos/test/default-config/contents/.github/test-app.yml": "404.yml",
 		"/repos/test/.github":                       "dot-github.yml",
 		"/repos/test/.github/contents/test-app.yml": "dot-github-contents.yml",
+
+		"/repos/test/default-config-remote-ref/contents/.github-remote/test-app.yml": "404.yml",
+		"/repos/test/.github-remote":               "remote-config.yml",
+		"/repos/test/config/contents/test-app.yml": "remote-ref-contents.yml",
 	} {
 		rp.AddRule(ExactPathMatcher(route), filepath.Join("testdata", f))
 	}


### PR DESCRIPTION
Today, the `appconfig` package supports a bunch of nice remote reference handling. However, one limitation for the new default configuration is that the org defaults cannot be remote references.

It would be nice if org defaults could choose to be remotes and allow some policy consolidation when certain orgs chose to use the same default config.