### PR TITLE
Fix nil pointer panic when using default transport

### DIFF
--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -291,8 +291,15 @@ func (c *clientCreator) NewTokenSourceV4Client(ts oauth2.TokenSource) (*githubv4
 }
 
 func (c *clientCreator) newHTTPClient() *http.Client {
+	transport := c.transport
+	if transport == nil {
+		// While http.Client will use the default when given a a nil transport,
+		// we assume a non-nil transport when applying middleware
+		transport = http.DefaultTransport
+	}
+
 	return &http.Client{
-		Transport: c.transport,
+		Transport: transport,
 		Timeout:   c.timeout,
 	}
 }


### PR DESCRIPTION
This was a regression introduced by the `WithTransport` option. Fixes #104.