### PR TITLE
Add logging for client request and response bodies

### DIFF
--- a/githubapp/middleware.go
+++ b/githubapp/middleware.go
@@ -15,17 +15,12 @@
 package githubapp
 
 import (
-	"bytes"
 	"fmt"
-	"io"
 	"net/http"
-	"regexp"
 	"strconv"
-	"time"
 
 	"github.com/gregjones/httpcache"
 	"github.com/rcrowley/go-metrics"
-	"github.com/rs/zerolog"
 )
 
 const (
@@ -111,131 +106,6 @@ func bucketStatus(status int) string {
 		return MetricsKeyRequests5xx
 	}
 	return ""
-}
-
-// ClientLogging creates client middleware that logs request and response
-// information at the given level. If the request fails without creating a
-// response, it is logged with a status code of -1. The middleware uses a
-// logger from the request context.
-func ClientLogging(lvl zerolog.Level, opts ...ClientLoggingOption) ClientMiddleware {
-	var options clientLoggingOptions
-	for _, opt := range opts {
-		opt(&options)
-	}
-
-	return func(next http.RoundTripper) http.RoundTripper {
-		return roundTripperFunc(func(r *http.Request) (*http.Response, error) {
-			var reqBody []byte
-			if requestMatches(r, options.RequestBodyPatterns) {
-				var err error
-				if r, reqBody, err = mirrorRequestBody(r); err != nil {
-					return nil, err
-				}
-			}
-
-			start := time.Now()
-			res, err := next.RoundTrip(r)
-			elapsed := time.Now().Sub(start)
-
-			evt := zerolog.Ctx(r.Context()).
-				WithLevel(lvl).
-				Str("method", r.Method).
-				Str("path", r.URL.String()).
-				Dur("elapsed", elapsed)
-
-			if reqBody != nil {
-				evt.Bytes("request_body", reqBody)
-			}
-
-			if res != nil {
-				cached := res.Header.Get(httpcache.XFromCache) != ""
-				evt.Int("status", res.StatusCode).
-					Int64("size", res.ContentLength).
-					Bool("cached", cached)
-			} else {
-				evt.Int("status", -1).
-					Int64("size", -1).
-					Bool("cached", false)
-			}
-
-			evt.Msg("github_request")
-			return res, err
-		})
-	}
-}
-
-// ClientLoggingOption controls behavior of client request logs.
-type ClientLoggingOption func(*clientLoggingOptions)
-
-// LogRequestBody enables request body logging for requests to paths matching
-// any of the regular expressions in patterns. It panics if any of the patterns
-// is not a valid regular expression.
-func LogRequestBody(patterns ...string) ClientLoggingOption {
-	regexps := compileRegexps(patterns)
-	return func(opts *clientLoggingOptions) {
-		opts.RequestBodyPatterns = regexps
-	}
-}
-
-// LogResponseBody enables response body logging for requests to paths matching
-// any of the regular expressions in patterns. It panics if any of the patterns
-// is not a valid regular expression.
-func LogResponseBody(patterns ...string) ClientLoggingOption {
-	regexps := compileRegexps(patterns)
-	return func(opts *clientLoggingOptions) {
-		opts.ResponseBodyPatterns = regexps
-	}
-}
-
-func mirrorRequestBody(r *http.Request) (*http.Request, []byte, error) {
-	switch {
-	case r.Body == nil:
-		return r, []byte{}, nil
-
-	case r.GetBody != nil:
-		br, err := r.GetBody()
-		if err != nil {
-			return r, nil, err
-		}
-		defer br.Close() // TODO(bkeyes): handle this error?
-
-		body, err := io.ReadAll(br)
-		return r, body, err
-
-	default:
-		defer r.Body.Close() // TODO(bkeyes): handle this error?
-
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			return r, nil, err
-		}
-
-		rCopy := r.Clone(r.Context())
-		rCopy.Body = io.NopCloser(bytes.NewReader(body))
-		return rCopy, body, nil
-	}
-}
-
-func compileRegexps(pats []string) []*regexp.Regexp {
-	regexps := make([]*regexp.Regexp, len(pats))
-	for i, p := range pats {
-		regexps[i] = regexp.MustCompile(p)
-	}
-	return regexps
-}
-
-func requestMatches(r *http.Request, pats []*regexp.Regexp) bool {
-	for _, pat := range pats {
-		if pat.MatchString(r.URL.Path) {
-			return true
-		}
-	}
-	return false
-}
-
-type clientLoggingOptions struct {
-	RequestBodyPatterns  []*regexp.Regexp
-	ResponseBodyPatterns []*regexp.Regexp
 }
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/githubapp/middleware_logging.go
+++ b/githubapp/middleware_logging.go
@@ -1,0 +1,152 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubapp
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/gregjones/httpcache"
+	"github.com/rs/zerolog"
+)
+
+// ClientLogging creates client middleware that logs request and response
+// information at the given level. If the request fails without creating a
+// response, it is logged with a status code of -1. The middleware uses a
+// logger from the request context.
+func ClientLogging(lvl zerolog.Level, opts ...ClientLoggingOption) ClientMiddleware {
+	var options clientLoggingOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return func(next http.RoundTripper) http.RoundTripper {
+		return roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+			var reqBody []byte
+			if requestMatches(r, options.RequestBodyPatterns) {
+				var err error
+				if r, reqBody, err = mirrorRequestBody(r); err != nil {
+					return nil, err
+				}
+			}
+
+			start := time.Now()
+			res, err := next.RoundTrip(r)
+			elapsed := time.Now().Sub(start)
+
+			evt := zerolog.Ctx(r.Context()).
+				WithLevel(lvl).
+				Str("method", r.Method).
+				Str("path", r.URL.String()).
+				Dur("elapsed", elapsed)
+
+			if reqBody != nil {
+				evt.Bytes("request_body", reqBody)
+			}
+
+			if res != nil {
+				cached := res.Header.Get(httpcache.XFromCache) != ""
+				evt.Int("status", res.StatusCode).
+					Int64("size", res.ContentLength).
+					Bool("cached", cached)
+			} else {
+				evt.Int("status", -1).
+					Int64("size", -1).
+					Bool("cached", false)
+			}
+
+			evt.Msg("github_request")
+			return res, err
+		})
+	}
+}
+
+// ClientLoggingOption controls behavior of client request logs.
+type ClientLoggingOption func(*clientLoggingOptions)
+
+// LogRequestBody enables request body logging for requests to paths matching
+// any of the regular expressions in patterns. It panics if any of the patterns
+// is not a valid regular expression.
+func LogRequestBody(patterns ...string) ClientLoggingOption {
+	regexps := compileRegexps(patterns)
+	return func(opts *clientLoggingOptions) {
+		opts.RequestBodyPatterns = regexps
+	}
+}
+
+// LogResponseBody enables response body logging for requests to paths matching
+// any of the regular expressions in patterns. It panics if any of the patterns
+// is not a valid regular expression.
+func LogResponseBody(patterns ...string) ClientLoggingOption {
+	regexps := compileRegexps(patterns)
+	return func(opts *clientLoggingOptions) {
+		opts.ResponseBodyPatterns = regexps
+	}
+}
+
+func mirrorRequestBody(r *http.Request) (*http.Request, []byte, error) {
+	switch {
+	case r.Body == nil || r.Body == http.NoBody:
+		return r, []byte{}, nil
+
+	case r.GetBody != nil:
+		br, err := r.GetBody()
+		if err != nil {
+			return r, nil, err
+		}
+		body, err := io.ReadAll(br)
+		closeBody(br)
+		return r, body, err
+
+	default:
+		body, err := io.ReadAll(r.Body)
+		closeBody(r.Body)
+		if err != nil {
+			return r, nil, err
+		}
+		rCopy := r.Clone(r.Context())
+		rCopy.Body = io.NopCloser(bytes.NewReader(body))
+		return rCopy, body, nil
+	}
+}
+
+func compileRegexps(pats []string) []*regexp.Regexp {
+	regexps := make([]*regexp.Regexp, len(pats))
+	for i, p := range pats {
+		regexps[i] = regexp.MustCompile(p)
+	}
+	return regexps
+}
+
+func requestMatches(r *http.Request, pats []*regexp.Regexp) bool {
+	for _, pat := range pats {
+		if pat.MatchString(r.URL.Path) {
+			return true
+		}
+	}
+	return false
+}
+
+func closeBody(b io.ReadCloser) {
+	_ = b.Close() // per http.Transport impl, ignoring close errors is fine
+}
+
+type clientLoggingOptions struct {
+	RequestBodyPatterns  []*regexp.Regexp
+	ResponseBodyPatterns []*regexp.Regexp
+}

--- a/githubapp/middleware_logging_test.go
+++ b/githubapp/middleware_logging_test.go
@@ -1,0 +1,192 @@
+// Copyright 2022 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestClientLogging(t *testing.T) {
+	t.Run("requestBody", func(t *testing.T) {
+		req, out := newLoggingRequest("GET", "https://test.domain/path", []byte("The request"))
+		rt := newStaticRoundTripper(200, []byte("The response"))
+
+		logMiddleware := ClientLogging(zerolog.InfoLevel, LogRequestBody(".*"))
+		rt = logMiddleware(rt)
+
+		_, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("unexpected error making request: %v", err)
+		}
+
+		assertLogFields(t, out.Bytes(), map[string]interface{}{
+			"method":       "GET",
+			"status":       float64(200),
+			"request_body": "The request",
+		})
+	})
+
+	t.Run("requestBodyNoMatch", func(t *testing.T) {
+		req, out := newLoggingRequest("GET", "https://test.domain/path", []byte("The request"))
+		rt := newStaticRoundTripper(200, []byte("The response"))
+
+		logMiddleware := ClientLogging(zerolog.InfoLevel, LogRequestBody("^/log-me$"))
+		rt = logMiddleware(rt)
+
+		_, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("unexpected error making request: %v", err)
+		}
+
+		assertLogFields(t, out.Bytes(), map[string]interface{}{
+			"method":       "GET",
+			"status":       float64(200),
+			"request_body": missingField,
+		})
+	})
+
+	t.Run("requestBodyNoBody", func(t *testing.T) {
+		req, out := newLoggingRequest("GET", "https://test.domain/path", nil)
+		rt := newStaticRoundTripper(200, []byte("The response"))
+
+		logMiddleware := ClientLogging(zerolog.InfoLevel, LogRequestBody(".*"))
+		rt = logMiddleware(rt)
+
+		_, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("unexpected error making request: %v", err)
+		}
+
+		assertLogFields(t, out.Bytes(), map[string]interface{}{
+			"method":       "GET",
+			"status":       float64(200),
+			"request_body": "",
+		})
+	})
+
+	t.Run("responseBody", func(t *testing.T) {
+		req, out := newLoggingRequest("GET", "https://test.domain/path", []byte("The request"))
+		rt := newStaticRoundTripper(200, []byte("The response"))
+
+		logMiddleware := ClientLogging(zerolog.InfoLevel, LogResponseBody(".*"))
+		rt = logMiddleware(rt)
+
+		_, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("unexpected error making request: %v", err)
+		}
+
+		assertLogFields(t, out.Bytes(), map[string]interface{}{
+			"method":        "GET",
+			"status":        float64(200),
+			"response_body": "The response",
+		})
+	})
+
+	t.Run("responseBodyNoMatch", func(t *testing.T) {
+		req, out := newLoggingRequest("GET", "https://test.domain/path", []byte("The request"))
+		rt := newStaticRoundTripper(200, []byte("The response"))
+
+		logMiddleware := ClientLogging(zerolog.InfoLevel, LogResponseBody("^/log-me$"))
+		rt = logMiddleware(rt)
+
+		_, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("unexpected error making request: %v", err)
+		}
+
+		assertLogFields(t, out.Bytes(), map[string]interface{}{
+			"method":        "GET",
+			"status":        float64(200),
+			"response_body": missingField,
+		})
+	})
+}
+
+func newLoggingRequest(method, url string, body []byte) (*http.Request, *bytes.Buffer) {
+	var out bytes.Buffer
+	logger := zerolog.New(&out)
+
+	ctx := logger.WithContext(context.Background())
+
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+
+	r, err := http.NewRequestWithContext(ctx, method, url, reader)
+	if err != nil {
+		panic(fmt.Errorf("failed to create request: %w", err))
+	}
+
+	return r, &out
+}
+
+func newStaticRoundTripper(status int, body []byte) http.RoundTripper {
+	return roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		if r.Body != nil {
+			_, _ = io.ReadAll(r.Body)
+			_ = r.Body.Close()
+		}
+
+		res := httptest.NewRecorder()
+		res.WriteHeader(status)
+		_, _ = res.Write(body)
+		return res.Result(), nil
+	})
+}
+
+var missingField struct{}
+
+func assertLogFields(t *testing.T, out []byte, expected map[string]interface{}) {
+	t.Logf("log output: %s", out)
+
+	var actual map[string]interface{}
+	if err := json.Unmarshal(out, &actual); err != nil {
+		t.Fatalf("unexpected error unmarshalling log fields: %v", err)
+	}
+
+	for k, v := range expected {
+		actualV, exists := actual[k]
+		if v == missingField {
+			if exists {
+				t.Errorf("key %q should not exist in output", k)
+			}
+			continue
+		}
+		if !exists {
+			t.Errorf("expected key %q does not exist", k)
+			continue
+		}
+
+		if !reflect.DeepEqual(v, actualV) {
+			t.Errorf("incorrect value for key %q\nexpected: %v (%T)\n  actual: %v (%T)", k,
+				v, v,
+				actualV, actualV,
+			)
+			continue
+		}
+	}
+}


### PR DESCRIPTION
I mostly want this for GraphQL, so that we can inspect the queries made by applications. It seemed easy enough to generalize, so I included the ability to log any client request or response body. Since logging this stuff can be noisy, expensive, or leak sensitive data, it is disabled by default. Individual applications can choose if they want to log all paths or only specific paths.

Putting up a draft PR while I work through the rest of this. Currently, request body logging is implemented but untested. I still need to implement response body logging.

Fixes #49.