### PR TITLE
Use Go version from .palantir/go-version file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,16 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Set Go version
+      id: go_version
+      run: |
+        GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
+        echo "::set-output name=version::${GO_VERSION}"
+
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: ${{ steps.go_version.outputs.version }}
 
     - name: Cache Godel assets
       uses: actions/cache@v2


### PR DESCRIPTION
This opts us in to automatic version updates via Excavator and avoids
having to track the version in two places.