### PR TITLE
Improve handler panic reporting

### DIFF
--- a/githubapp/errors.go
+++ b/githubapp/errors.go
@@ -16,12 +16,20 @@ package githubapp
 
 import (
 	"fmt"
+	"io"
+	"runtime"
 
 	"github.com/rcrowley/go-metrics"
 )
 
 const (
 	MetricsKeyHandlerError = "github.handler.error"
+)
+
+var (
+	// HandlerRecoverStackDepth is the max depth of stack trace to recover on a
+	// handler panic.
+	HandlerRecoverStackDepth = 32
 )
 
 func errorCounter(r metrics.Registry, event string) metrics.Counter {
@@ -34,4 +42,70 @@ func errorCounter(r metrics.Registry, event string) metrics.Counter {
 		key = fmt.Sprintf("%s[event:%s]", key, event)
 	}
 	return metrics.GetOrRegisterCounter(key, r)
+}
+
+// HandlerPanicError is an error created from a recovered handler panic.
+type HandlerPanicError struct {
+	value interface{}
+	stack []runtime.Frame
+}
+
+// Value returns the exact value with which panic() was called.
+func (e HandlerPanicError) Value() interface{} {
+	return e.value
+}
+
+// StackTrace returns the stack of the panicking goroutine.
+func (e HandlerPanicError) StackTrace() []runtime.Frame {
+	return e.stack
+}
+
+// Format formats the error optionally including the stack trace.
+//
+//   %s    the error message
+//   %v    the error message and the source file and line number for each stack frame
+//
+// Format accepts the following flags:
+//
+//   %+v   the error message and the function, file, and line for each stack frame
+//
+func (e HandlerPanicError) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		_, _ = io.WriteString(s, e.Error())
+	case 'v':
+		_, _ = io.WriteString(s, e.Error())
+		for _, f := range e.stack {
+			_, _ = io.WriteString(s, "\n")
+			if s.Flag('+') {
+				_, _ = fmt.Fprintf(s, "%s\n\t", f.Function)
+			}
+			_, _ = fmt.Fprintf(s, "%s:%d", f.File, f.Line)
+		}
+	}
+}
+
+func (e HandlerPanicError) Error() string {
+	v := e.value
+	if err, ok := v.(error); ok {
+		v = err.Error()
+	}
+	return fmt.Sprintf("panic: %v", v)
+}
+
+func getStack(skip int) []runtime.Frame {
+	rpc := make([]uintptr, HandlerRecoverStackDepth)
+
+	n := runtime.Callers(skip+2, rpc)
+	frames := runtime.CallersFrames(rpc[0:n])
+
+	var stack []runtime.Frame
+	for {
+		f, more := frames.Next()
+		if !more {
+			break
+		}
+		stack = append(stack, f)
+	}
+	return stack
 }


### PR DESCRIPTION
Stack traces for handler panics were lost, making it hard to determine where the panic actually happened. Now, stack traces are captured by a special error type so that handlers can print them. By default, nothing actually changes, but I plan to extend the default configuration of go-baseapp so that these errors are formatted with stack traces in logs.

I copied the error code from my implementation in `bluekeyes/hatpear` so that they'll share the same interface. The `pkg/errors` package has a similar interface, but uses package-specific types. Using standard library types seemed preferrable, even though we have a dependency on `pkg/errors` already.

Closes #47. Requires apps to use https://github.com/palantir/go-baseapp/pull/87 or implement their own error handlers to get the benefits.