### PR TITLE
add a caching implementation for InstallationsService

### DIFF
--- a/githubapp/installations_caching.go
+++ b/githubapp/installations_caching.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package githubapp
 
 import (

--- a/githubapp/installations_caching.go
+++ b/githubapp/installations_caching.go
@@ -73,7 +73,7 @@ func (c *cachingInstallationsService) GetByOwner(ctx context.Context, owner stri
 
 func (c *cachingInstallationsService) GetByRepository(ctx context.Context, owner, name string) (Installation, error) {
 	// if installation is in cache, return it
-	key := fmt.Sprintf(owner, "/", name)
+	key := fmt.Sprintf("%s/%s", owner, name)
 	val, ok := c.cache.Get(key)
 	if ok {
 		if install, ok := val.(Installation); ok {

--- a/githubapp/installations_caching.go
+++ b/githubapp/installations_caching.go
@@ -1,0 +1,77 @@
+package githubapp
+
+import (
+	"context"
+	"fmt"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/pkg/errors"
+)
+
+// NewCachingInstallationsService returns an InstallationsService that always queries GitHub. It should be created with
+// a client that authenticates as the target.
+// It uses an LRU cache of the provided capacity to store app installation info for repositories and owners and returns
+// cached installation info when a cache hit exists.
+//
+// This should be used in cases where installation info needs to be queried multiple times across a short timespan as
+// the installation ID can change if an administrator uninstalls then reinstalls the app, in which case a cache hit
+// would return the wrong installation ID. Use with caution for long-lived usecases.
+func NewCachingInstallationsService(delegate InstallationsService, capacity int) (InstallationsService, error) {
+	cache, err := lru.New(capacity)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create cache")
+	}
+
+	return &cachingInstallationsService{
+		cache:    cache,
+		delegate: delegate,
+	}, nil
+}
+
+type cachingInstallationsService struct {
+	cache    *lru.Cache
+	delegate InstallationsService
+}
+
+func (c *cachingInstallationsService) ListAll(ctx context.Context) ([]Installation, error) {
+	// ListAll is not cached due to the higher probability of installation IDs changing when listing all installations
+	// across all organizations that the app is installed to
+	return c.delegate.ListAll(ctx)
+}
+
+func (c *cachingInstallationsService) GetByOwner(ctx context.Context, owner string) (Installation, error) {
+	// if installation is in cache, return it
+	val, ok := c.cache.Get(owner)
+	if ok {
+		if install, ok := val.(Installation); ok {
+			return install, nil
+		}
+	}
+
+	// otherwise, get installation info, save to cache, and return
+	install, err := c.delegate.GetByOwner(ctx, owner)
+	if err != nil {
+		return Installation{}, err
+	}
+	c.cache.Add(owner, install)
+	return install, nil
+}
+
+func (c *cachingInstallationsService) GetByRepository(ctx context.Context, owner, name string) (Installation, error) {
+	// if installation is in cache, return it
+	key := fmt.Sprintf(owner, "/", name)
+	val, ok := c.cache.Get(key)
+	if ok {
+		if install, ok := val.(Installation); ok {
+			return install, nil
+		}
+	}
+
+	// otherwise, get installation info, save to cache, and return
+	install, err := c.delegate.GetByRepository(ctx, owner, name)
+	if err != nil {
+		return Installation{}, err
+	}
+	c.cache.Add(key, install)
+	return install, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-github/v53 v53.2.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hashicorp/golang-lru v0.6.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/rs/zerolog v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZb
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
When querying repository info many times in succession, it is useful to cache results about the app installation in order to reduce API requests to github. This PR adds a `CachingInstallationsService` which uses a TTL based cache to store results about app installation info with regards to repositories or owners.