### PR TITLE
Fix golang setup and build in "CodeQL" workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,5 +30,19 @@ jobs:
       with:
         languages: ${{ matrix.language }}
 
+    - name: Set Go version
+      id: go_version
+      run: |
+        GO_VERSION=$(cat .palantir/go-version | sed 's/^go//' )
+        echo "::set-output name=version::${GO_VERSION}"
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ steps.go_version.outputs.version }}
+
+    - name: Autobuild for CodeQL
+      uses: github/codeql-action/autobuild@v3
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Adds steps to the "CodeQL" GH Actions workflow in order to:
  - setup (install) golang on the GH Actions runner;
  - run a golang build that CodeQL can trace, scan, and analyze.

Uses "codeql-action/autobuild" in an attempt to simplify the workflow.