### PR TITLE
Logging Middleware: Add GitHub API Rate Limiting information

### DIFF
--- a/githubapp/middleware.go
+++ b/githubapp/middleware.go
@@ -75,8 +75,8 @@ func ClientMetrics(registry metrics.Registry) ClientMiddleware {
 				remainingMetric := fmt.Sprintf("%s[installation:%d]", MetricsKeyRateLimitRemaining, installationID)
 
 				// Headers from https://developer.github.com/v3/#rate-limiting
-				updateRegistryForHeader(res.Header, "X-RateLimit-Limit", metrics.GetOrRegisterGauge(limitMetric, registry))
-				updateRegistryForHeader(res.Header, "X-RateLimit-Remaining", metrics.GetOrRegisterGauge(remainingMetric, registry))
+				updateRegistryForHeader(res.Header, HTTPHeaderRateLimit, metrics.GetOrRegisterGauge(limitMetric, registry))
+				updateRegistryForHeader(res.Header, HTTPHeaderRateRemaining, metrics.GetOrRegisterGauge(remainingMetric, registry))
 			}
 
 			return res, err

--- a/githubapp/middleware.go
+++ b/githubapp/middleware.go
@@ -75,8 +75,8 @@ func ClientMetrics(registry metrics.Registry) ClientMiddleware {
 				remainingMetric := fmt.Sprintf("%s[installation:%d]", MetricsKeyRateLimitRemaining, installationID)
 
 				// Headers from https://developer.github.com/v3/#rate-limiting
-				updateRegistryForHeader(res.Header, HTTPHeaderRateLimit, metrics.GetOrRegisterGauge(limitMetric, registry))
-				updateRegistryForHeader(res.Header, HTTPHeaderRateRemaining, metrics.GetOrRegisterGauge(remainingMetric, registry))
+				updateRegistryForHeader(res.Header, httpHeaderRateLimit, metrics.GetOrRegisterGauge(limitMetric, registry))
+				updateRegistryForHeader(res.Header, httpHeaderRateRemaining, metrics.GetOrRegisterGauge(remainingMetric, registry))
 				// TODO Think about to add X-Ratelimit-Used, X-Ratelimit-Reset and X-Ratelimit-Resource as well
 			}
 

--- a/githubapp/middleware.go
+++ b/githubapp/middleware.go
@@ -77,6 +77,7 @@ func ClientMetrics(registry metrics.Registry) ClientMiddleware {
 				// Headers from https://developer.github.com/v3/#rate-limiting
 				updateRegistryForHeader(res.Header, HTTPHeaderRateLimit, metrics.GetOrRegisterGauge(limitMetric, registry))
 				updateRegistryForHeader(res.Header, HTTPHeaderRateRemaining, metrics.GetOrRegisterGauge(remainingMetric, registry))
+				// TODO Think about to add X-Ratelimit-Used, X-Ratelimit-Reset and X-Ratelimit-Resource as well
 			}
 
 			return res, err

--- a/githubapp/middleware_logging.go
+++ b/githubapp/middleware_logging.go
@@ -206,6 +206,11 @@ func closeBody(b io.ReadCloser) {
 }
 
 func addRateLimitInformationToLog(loggingOptions *RateLimitLoggingOption, evt *zerolog.Event, res *http.Response) {
+	// Exit early if no rate limit information is requested
+	if loggingOptions == nil {
+		return
+	}
+
 	if limitHeader := res.Header.Get(httpHeaderRateLimit); loggingOptions.Limit && limitHeader != "" {
 		limit, _ := strconv.Atoi(limitHeader)
 		evt.Int("ratelimit-limit", limit)

--- a/githubapp/middleware_logging.go
+++ b/githubapp/middleware_logging.go
@@ -139,9 +139,9 @@ func LogResponseBody(patterns ...string) ClientLoggingOption {
 	}
 }
 
-// SetRateLimitInformation defines which rate limit information like
+// LogRateLimitInformation defines which rate limit information like
 // the number of requests remaining in the current rate limit window is getting logged.
-func SetRateLimitInformation(options *RateLimitLoggingOption) ClientLoggingOption {
+func LogRateLimitInformation(options *RateLimitLoggingOption) ClientLoggingOption {
 	return func(opts *clientLoggingOptions) {
 		opts.LogRateLimitInformation = options
 	}

--- a/githubapp/middleware_logging.go
+++ b/githubapp/middleware_logging.go
@@ -19,10 +19,19 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/gregjones/httpcache"
 	"github.com/rs/zerolog"
+)
+
+const (
+	headerRateLimit     = "X-Ratelimit-Limit"
+	headerRateRemaining = "X-Ratelimit-Remaining"
+	headerRateUsed      = "X-Ratelimit-Used"
+	headerRateReset     = "X-Ratelimit-Reset"
+	headerRateResource  = "X-Ratelimit-Resource"
 )
 
 // ClientLogging creates client middleware that logs request and response
@@ -83,6 +92,10 @@ func ClientLogging(lvl zerolog.Level, opts ...ClientLoggingOption) ClientMiddlew
 					Int64("size", -1)
 			}
 
+			if options.LogRateLimitInformation {
+				addRateLimitInformationToLog(evt, res)
+			}
+
 			evt.Msg("github_request")
 			return res, err
 		})
@@ -95,6 +108,9 @@ type ClientLoggingOption func(*clientLoggingOptions)
 type clientLoggingOptions struct {
 	RequestBodyPatterns  []*regexp.Regexp
 	ResponseBodyPatterns []*regexp.Regexp
+
+	// Output control
+	LogRateLimitInformation bool
 }
 
 // LogRequestBody enables request body logging for requests to paths matching
@@ -114,6 +130,22 @@ func LogResponseBody(patterns ...string) ClientLoggingOption {
 	regexps := compileRegexps(patterns)
 	return func(opts *clientLoggingOptions) {
 		opts.ResponseBodyPatterns = regexps
+	}
+}
+
+// EnableRateLimitInformation enables logging of rate limit information like
+// the number of requests remaining in the current rate limit window.
+func EnableRateLimitInformation() ClientLoggingOption {
+	return func(opts *clientLoggingOptions) {
+		opts.LogRateLimitInformation = true
+	}
+}
+
+// DisableRateLimitInformation disables logging of rate limit information like
+// the number of requests remaining in the current rate limit window.
+func DisableRateLimitInformation() ClientLoggingOption {
+	return func(opts *clientLoggingOptions) {
+		opts.LogRateLimitInformation = false
 	}
 }
 
@@ -173,4 +205,27 @@ func requestMatches(r *http.Request, pats []*regexp.Regexp) bool {
 
 func closeBody(b io.ReadCloser) {
 	_ = b.Close() // per http.Transport impl, ignoring close errors is fine
+}
+
+func addRateLimitInformationToLog(evt *zerolog.Event, res *http.Response) {
+	if limitHeader := res.Header.Get(headerRateLimit); limitHeader != "" {
+		limit, _ := strconv.Atoi(limitHeader)
+		evt.Int("ratelimit-limit", limit)
+	}
+	if remainingHeader := res.Header.Get(headerRateRemaining); remainingHeader != "" {
+		remaining, _ := strconv.Atoi(remainingHeader)
+		evt.Int("ratelimit-remaining", remaining)
+	}
+	if usedHeader := res.Header.Get(headerRateUsed); usedHeader != "" {
+		used, _ := strconv.Atoi(usedHeader)
+		evt.Int("ratelimit-used", used)
+	}
+	if resetHeader := res.Header.Get(headerRateReset); resetHeader != "" {
+		if v, _ := strconv.ParseInt(resetHeader, 10, 64); v != 0 {
+			evt.Time("ratelimit-reset", time.Unix(v, 0))
+		}
+	}
+	if resourceHeader := res.Header.Get(headerRateResource); resourceHeader != "" {
+		evt.Str("ratelimit-resource", resourceHeader)
+	}
 }

--- a/githubapp/middleware_logging.go
+++ b/githubapp/middleware_logging.go
@@ -211,24 +211,27 @@ func addRateLimitInformationToLog(loggingOptions *RateLimitLoggingOption, evt *z
 		return
 	}
 
+	rateLimitDict := zerolog.Dict()
 	if limitHeader := res.Header.Get(httpHeaderRateLimit); loggingOptions.Limit && limitHeader != "" {
 		limit, _ := strconv.Atoi(limitHeader)
-		evt.Int("ratelimit-limit", limit)
+		rateLimitDict.Int("limit", limit)
 	}
 	if remainingHeader := res.Header.Get(httpHeaderRateRemaining); loggingOptions.Remaining && remainingHeader != "" {
 		remaining, _ := strconv.Atoi(remainingHeader)
-		evt.Int("ratelimit-remaining", remaining)
+		rateLimitDict.Int("remaining", remaining)
 	}
 	if usedHeader := res.Header.Get(httpHeaderRateUsed); loggingOptions.Used && usedHeader != "" {
 		used, _ := strconv.Atoi(usedHeader)
-		evt.Int("ratelimit-used", used)
+		rateLimitDict.Int("used", used)
 	}
 	if resetHeader := res.Header.Get(httpHeaderRateReset); loggingOptions.Reset && resetHeader != "" {
 		if v, _ := strconv.ParseInt(resetHeader, 10, 64); v != 0 {
-			evt.Time("ratelimit-reset", time.Unix(v, 0))
+			rateLimitDict.Time("reset", time.Unix(v, 0))
 		}
 	}
 	if resourceHeader := res.Header.Get(httpHeaderRateResource); loggingOptions.Resource && resourceHeader != "" {
-		evt.Str("ratelimit-resource", resourceHeader)
+		rateLimitDict.Str("resource", resourceHeader)
 	}
+
+	evt.Dict("ratelimit", rateLimitDict)
 }

--- a/githubapp/middleware_logging.go
+++ b/githubapp/middleware_logging.go
@@ -27,11 +27,11 @@ import (
 )
 
 const (
-	HTTPHeaderRateLimit     = "X-Ratelimit-Limit"
-	HTTPHeaderRateRemaining = "X-Ratelimit-Remaining"
-	HTTPHeaderRateUsed      = "X-Ratelimit-Used"
-	HTTPHeaderRateReset     = "X-Ratelimit-Reset"
-	HTTPHeaderRateResource  = "X-Ratelimit-Resource"
+	httpHeaderRateLimit     = "X-Ratelimit-Limit"
+	httpHeaderRateRemaining = "X-Ratelimit-Remaining"
+	httpHeaderRateUsed      = "X-Ratelimit-Used"
+	httpHeaderRateReset     = "X-Ratelimit-Reset"
+	httpHeaderRateResource  = "X-Ratelimit-Resource"
 )
 
 // ClientLogging creates client middleware that logs request and response
@@ -206,24 +206,24 @@ func closeBody(b io.ReadCloser) {
 }
 
 func addRateLimitInformationToLog(loggingOptions *RateLimitLoggingOption, evt *zerolog.Event, res *http.Response) {
-	if limitHeader := res.Header.Get(HTTPHeaderRateLimit); loggingOptions.Limit && limitHeader != "" {
+	if limitHeader := res.Header.Get(httpHeaderRateLimit); loggingOptions.Limit && limitHeader != "" {
 		limit, _ := strconv.Atoi(limitHeader)
 		evt.Int("ratelimit-limit", limit)
 	}
-	if remainingHeader := res.Header.Get(HTTPHeaderRateRemaining); loggingOptions.Remaining && remainingHeader != "" {
+	if remainingHeader := res.Header.Get(httpHeaderRateRemaining); loggingOptions.Remaining && remainingHeader != "" {
 		remaining, _ := strconv.Atoi(remainingHeader)
 		evt.Int("ratelimit-remaining", remaining)
 	}
-	if usedHeader := res.Header.Get(HTTPHeaderRateUsed); loggingOptions.Used && usedHeader != "" {
+	if usedHeader := res.Header.Get(httpHeaderRateUsed); loggingOptions.Used && usedHeader != "" {
 		used, _ := strconv.Atoi(usedHeader)
 		evt.Int("ratelimit-used", used)
 	}
-	if resetHeader := res.Header.Get(HTTPHeaderRateReset); loggingOptions.Reset && resetHeader != "" {
+	if resetHeader := res.Header.Get(httpHeaderRateReset); loggingOptions.Reset && resetHeader != "" {
 		if v, _ := strconv.ParseInt(resetHeader, 10, 64); v != 0 {
 			evt.Time("ratelimit-reset", time.Unix(v, 0))
 		}
 	}
-	if resourceHeader := res.Header.Get(HTTPHeaderRateResource); loggingOptions.Resource && resourceHeader != "" {
+	if resourceHeader := res.Header.Get(httpHeaderRateResource); loggingOptions.Resource && resourceHeader != "" {
 		evt.Str("ratelimit-resource", resourceHeader)
 	}
 }

--- a/githubapp/middleware_logging.go
+++ b/githubapp/middleware_logging.go
@@ -92,10 +92,7 @@ func ClientLogging(lvl zerolog.Level, opts ...ClientLoggingOption) ClientMiddlew
 					Int64("size", -1)
 			}
 
-			if options.LogRateLimitInformation {
-				addRateLimitInformationToLog(evt, res)
-			}
-
+			addRateLimitInformationToLog(options.LogRateLimitInformation, evt, res)
 			evt.Msg("github_request")
 			return res, err
 		})
@@ -110,7 +107,16 @@ type clientLoggingOptions struct {
 	ResponseBodyPatterns []*regexp.Regexp
 
 	// Output control
-	LogRateLimitInformation bool
+	LogRateLimitInformation *RateLimitLoggingOption
+}
+
+// RateLimitLoggingOption controls which rate limit information is logged.
+type RateLimitLoggingOption struct {
+	Limit     bool
+	Remaining bool
+	Used      bool
+	Reset     bool
+	Resource  bool
 }
 
 // LogRequestBody enables request body logging for requests to paths matching
@@ -133,19 +139,11 @@ func LogResponseBody(patterns ...string) ClientLoggingOption {
 	}
 }
 
-// EnableRateLimitInformation enables logging of rate limit information like
-// the number of requests remaining in the current rate limit window.
-func EnableRateLimitInformation() ClientLoggingOption {
+// SetRateLimitInformation defines which rate limit information like
+// the number of requests remaining in the current rate limit window is getting logged.
+func SetRateLimitInformation(options *RateLimitLoggingOption) ClientLoggingOption {
 	return func(opts *clientLoggingOptions) {
-		opts.LogRateLimitInformation = true
-	}
-}
-
-// DisableRateLimitInformation disables logging of rate limit information like
-// the number of requests remaining in the current rate limit window.
-func DisableRateLimitInformation() ClientLoggingOption {
-	return func(opts *clientLoggingOptions) {
-		opts.LogRateLimitInformation = false
+		opts.LogRateLimitInformation = options
 	}
 }
 
@@ -207,25 +205,25 @@ func closeBody(b io.ReadCloser) {
 	_ = b.Close() // per http.Transport impl, ignoring close errors is fine
 }
 
-func addRateLimitInformationToLog(evt *zerolog.Event, res *http.Response) {
-	if limitHeader := res.Header.Get(HTTPHeaderRateLimit); limitHeader != "" {
+func addRateLimitInformationToLog(loggingOptions *RateLimitLoggingOption, evt *zerolog.Event, res *http.Response) {
+	if limitHeader := res.Header.Get(HTTPHeaderRateLimit); loggingOptions.Limit && limitHeader != "" {
 		limit, _ := strconv.Atoi(limitHeader)
 		evt.Int("ratelimit-limit", limit)
 	}
-	if remainingHeader := res.Header.Get(HTTPHeaderRateRemaining); remainingHeader != "" {
+	if remainingHeader := res.Header.Get(HTTPHeaderRateRemaining); loggingOptions.Remaining && remainingHeader != "" {
 		remaining, _ := strconv.Atoi(remainingHeader)
 		evt.Int("ratelimit-remaining", remaining)
 	}
-	if usedHeader := res.Header.Get(HTTPHeaderRateUsed); usedHeader != "" {
+	if usedHeader := res.Header.Get(HTTPHeaderRateUsed); loggingOptions.Used && usedHeader != "" {
 		used, _ := strconv.Atoi(usedHeader)
 		evt.Int("ratelimit-used", used)
 	}
-	if resetHeader := res.Header.Get(HTTPHeaderRateReset); resetHeader != "" {
+	if resetHeader := res.Header.Get(HTTPHeaderRateReset); loggingOptions.Reset && resetHeader != "" {
 		if v, _ := strconv.ParseInt(resetHeader, 10, 64); v != 0 {
 			evt.Time("ratelimit-reset", time.Unix(v, 0))
 		}
 	}
-	if resourceHeader := res.Header.Get(HTTPHeaderRateResource); resourceHeader != "" {
+	if resourceHeader := res.Header.Get(HTTPHeaderRateResource); loggingOptions.Resource && resourceHeader != "" {
 		evt.Str("ratelimit-resource", resourceHeader)
 	}
 }

--- a/githubapp/middleware_logging.go
+++ b/githubapp/middleware_logging.go
@@ -27,11 +27,11 @@ import (
 )
 
 const (
-	headerRateLimit     = "X-Ratelimit-Limit"
-	headerRateRemaining = "X-Ratelimit-Remaining"
-	headerRateUsed      = "X-Ratelimit-Used"
-	headerRateReset     = "X-Ratelimit-Reset"
-	headerRateResource  = "X-Ratelimit-Resource"
+	HTTPHeaderRateLimit     = "X-Ratelimit-Limit"
+	HTTPHeaderRateRemaining = "X-Ratelimit-Remaining"
+	HTTPHeaderRateUsed      = "X-Ratelimit-Used"
+	HTTPHeaderRateReset     = "X-Ratelimit-Reset"
+	HTTPHeaderRateResource  = "X-Ratelimit-Resource"
 )
 
 // ClientLogging creates client middleware that logs request and response
@@ -208,24 +208,24 @@ func closeBody(b io.ReadCloser) {
 }
 
 func addRateLimitInformationToLog(evt *zerolog.Event, res *http.Response) {
-	if limitHeader := res.Header.Get(headerRateLimit); limitHeader != "" {
+	if limitHeader := res.Header.Get(HTTPHeaderRateLimit); limitHeader != "" {
 		limit, _ := strconv.Atoi(limitHeader)
 		evt.Int("ratelimit-limit", limit)
 	}
-	if remainingHeader := res.Header.Get(headerRateRemaining); remainingHeader != "" {
+	if remainingHeader := res.Header.Get(HTTPHeaderRateRemaining); remainingHeader != "" {
 		remaining, _ := strconv.Atoi(remainingHeader)
 		evt.Int("ratelimit-remaining", remaining)
 	}
-	if usedHeader := res.Header.Get(headerRateUsed); usedHeader != "" {
+	if usedHeader := res.Header.Get(HTTPHeaderRateUsed); usedHeader != "" {
 		used, _ := strconv.Atoi(usedHeader)
 		evt.Int("ratelimit-used", used)
 	}
-	if resetHeader := res.Header.Get(headerRateReset); resetHeader != "" {
+	if resetHeader := res.Header.Get(HTTPHeaderRateReset); resetHeader != "" {
 		if v, _ := strconv.ParseInt(resetHeader, 10, 64); v != 0 {
 			evt.Time("ratelimit-reset", time.Unix(v, 0))
 		}
 	}
-	if resourceHeader := res.Header.Get(headerRateResource); resourceHeader != "" {
+	if resourceHeader := res.Header.Get(HTTPHeaderRateResource); resourceHeader != "" {
 		evt.Str("ratelimit-resource", resourceHeader)
 	}
 }


### PR DESCRIPTION
## Context

This Pull Request adds the GitHub API Rate Limiting information into the Logging Middleware, if enabled.
It is disabled by default, as this can blow your log volume.

For more information on GitHub Rate Limiting, see https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit

## How to use it

```go
clientCreator, err := githubapp.NewDefaultCachingClientCreator(
	config.Github,
	githubapp.WithClientUserAgent(ClientUserAgent),
	githubapp.WithClientTimeout(60*time.Second),
	githubapp.WithClientCaching(false, func() httpcache.Cache { return httpTransportCache }),
	githubapp.WithClientMiddleware(
		githubapp.ClientMetrics(metricsRegistry),
		**githubapp.ClientLogging(zerolog.InfoLevel, githubapp.EnableRateLimitInformation()),**
	),
)
```

## Result

Log lines will look like

> 2025-01-25T21:55:48+01:00 INF github_request cached=false elapsed=529.904625 method=GET path=https://api.github.com/installation/repositories?per_page=100 ratelimit-limit=5000 ratelimit-remaining=4999 ratelimit-reset=2025-01-25T22:55:48+01:00 ratelimit-resource=core ratelimit-used=1 size=-1 status=200

## Depends on ...

Attention! This Pull Request depends on https://github.com/google/go-github/pull/3453

The fields `Used` and `Resource` are not part of `go-github` yet. If https://github.com/google/go-github/pull/3453 gets merged, the following steps are required to move this PR forward:

1. A new `google/go-github` version needs to be released
2. `google/go-github` need to be raised inside `palantir/go-githubapp`
3. This PR can move forward.

Step 2 can also be added into this PR.

## Missing work

- [ ] Unit tests

## Feedback

I open up this PR to get feedback early on, even if the PR is not mergeable yet.