### PR TITLE
Metrics: Expose `X-Ratelimit-Used` and `X-Ratelimit-Reset` as metric

### DIFF
--- a/githubapp/middleware.go
+++ b/githubapp/middleware.go
@@ -34,6 +34,7 @@ const (
 
 	MetricsKeyRateLimit          = "github.rate.limit"
 	MetricsKeyRateLimitRemaining = "github.rate.remaining"
+	MetricsKeyRateLimitUsed      = "github.rate.used"
 )
 
 // ClientMetrics creates client middleware that records metrics about all
@@ -73,11 +74,13 @@ func ClientMetrics(registry metrics.Registry) ClientMiddleware {
 
 				limitMetric := fmt.Sprintf("%s[installation:%d]", MetricsKeyRateLimit, installationID)
 				remainingMetric := fmt.Sprintf("%s[installation:%d]", MetricsKeyRateLimitRemaining, installationID)
+				usedMetric := fmt.Sprintf("%s[installation:%d]", MetricsKeyRateLimitUsed, installationID)
 
 				// Headers from https://developer.github.com/v3/#rate-limiting
 				updateRegistryForHeader(res.Header, httpHeaderRateLimit, metrics.GetOrRegisterGauge(limitMetric, registry))
 				updateRegistryForHeader(res.Header, httpHeaderRateRemaining, metrics.GetOrRegisterGauge(remainingMetric, registry))
-				// TODO Think about to add X-Ratelimit-Used, X-Ratelimit-Reset and X-Ratelimit-Resource as well
+				updateRegistryForHeader(res.Header, httpHeaderRateUsed, metrics.GetOrRegisterGauge(usedMetric, registry))
+				// TODO Think about to add X-Ratelimit-Reset and X-Ratelimit-Resource as well
 			}
 
 			return res, err

--- a/githubapp/middleware.go
+++ b/githubapp/middleware.go
@@ -35,6 +35,7 @@ const (
 	MetricsKeyRateLimit          = "github.rate.limit"
 	MetricsKeyRateLimitRemaining = "github.rate.remaining"
 	MetricsKeyRateLimitUsed      = "github.rate.used"
+	MetricsKeyRateLimitReset     = "github.rate.reset"
 )
 
 // ClientMetrics creates client middleware that records metrics about all
@@ -75,12 +76,14 @@ func ClientMetrics(registry metrics.Registry) ClientMiddleware {
 				limitMetric := fmt.Sprintf("%s[installation:%d]", MetricsKeyRateLimit, installationID)
 				remainingMetric := fmt.Sprintf("%s[installation:%d]", MetricsKeyRateLimitRemaining, installationID)
 				usedMetric := fmt.Sprintf("%s[installation:%d]", MetricsKeyRateLimitUsed, installationID)
+				resetMetric := fmt.Sprintf("%s[installation:%d]", MetricsKeyRateLimitReset, installationID)
 
 				// Headers from https://developer.github.com/v3/#rate-limiting
 				updateRegistryForHeader(res.Header, httpHeaderRateLimit, metrics.GetOrRegisterGauge(limitMetric, registry))
 				updateRegistryForHeader(res.Header, httpHeaderRateRemaining, metrics.GetOrRegisterGauge(remainingMetric, registry))
 				updateRegistryForHeader(res.Header, httpHeaderRateUsed, metrics.GetOrRegisterGauge(usedMetric, registry))
-				// TODO Think about to add X-Ratelimit-Reset and X-Ratelimit-Resource as well
+				updateRegistryForHeader(res.Header, httpHeaderRateReset, metrics.GetOrRegisterGauge(resetMetric, registry))
+				// TODO Think about to add X-Ratelimit-Resource as well
 			}
 
 			return res, err


### PR DESCRIPTION
This is a followup from https://github.com/palantir/go-githubapp/pull/413

In the PR, we expose the two data points X-Ratelimit-Used` and `X-Ratelimit-Reset` as metric.