### PR TITLE
Logging middleware: Fix invalid memory address panic if response is nil

### DIFF
--- a/githubapp/middleware_logging.go
+++ b/githubapp/middleware_logging.go
@@ -86,13 +86,14 @@ func ClientLogging(lvl zerolog.Level, opts ...ClientLoggingOption) ClientMiddlew
 				} else {
 					evt.Int64("size", size)
 				}
+
+				addRateLimitInformationToLog(options.LogRateLimitInformation, evt, res)
 			} else {
 				evt.Bool("cached", false).
 					Int("status", -1).
 					Int64("size", -1)
 			}
 
-			addRateLimitInformationToLog(options.LogRateLimitInformation, evt, res)
 			evt.Msg("github_request")
 			return res, err
 		})

--- a/githubapp/middleware_logging_test.go
+++ b/githubapp/middleware_logging_test.go
@@ -123,6 +123,27 @@ func TestClientLogging(t *testing.T) {
 			"response_body": missingField,
 		})
 	})
+
+	t.Run("nilRequest", func(t *testing.T) {
+		req, _ := newLoggingRequest("GET", "https://test.domain/path", []byte("The request"))
+		rt := newEmptyRoundTripper()
+
+		logMiddleware := ClientLogging(zerolog.InfoLevel, LogRateLimitInformation(&RateLimitLoggingOption{
+			Limit:     true,
+			Remaining: true,
+			Used:      true,
+			Reset:     true,
+			Resource:  true,
+		}))
+		rt = logMiddleware(rt)
+
+		_, err := rt.RoundTrip(req)
+		if err != nil {
+			t.Fatalf("unexpected error making request: %v", err)
+		}
+
+		// To ensure that this is not crashing
+	})
 }
 
 func newLoggingRequest(method, url string, body []byte) (*http.Request, *bytes.Buffer) {
@@ -155,6 +176,12 @@ func newStaticRoundTripper(status int, body []byte) http.RoundTripper {
 		res.WriteHeader(status)
 		_, _ = res.Write(body)
 		return res.Result(), nil
+	})
+}
+
+func newEmptyRoundTripper() http.RoundTripper {
+	return roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		return nil, nil
 	})
 }
 


### PR DESCRIPTION
In `ClientLogging` (or better: in the roundTripper), if the result of the next roundTripper is nil, `addRateLimitInformationToLog` will throw a nil panic.

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x2 addr=0x38 pc=0x102840ad4]
```

I added a test to replicate the behaviour.

Here is a full stack trace:

```
goroutine 69 [running]:
github.com/palantir/go-githubapp/githubapp.addRateLimitInformationToLog(0xc00026aecb, 0xc00029c1c0, 0x0)
	/go/pkg/mod/github.com/palantir/go-githubapp@v0.38.0/githubapp/middleware_logging.go:215 +0x6c
github.com/palantir/go-githubapp/githubapp.ClientLogging.func1.1(0xc000276500)
	/go/pkg/mod/github.com/palantir/go-githubapp@v0.38.0/githubapp/middleware_logging.go:95 +0x546
github.com/palantir/go-githubapp/githubapp.roundTripperFunc.RoundTrip(0xc00026c360, 0xc000276500)
	/go/pkg/mod/github.com/palantir/go-githubapp@v0.38.0/githubapp/middleware.go:121 +0x34
github.com/palantir/go-githubapp/githubapp.ClientMetrics.func1.1(0xc000276500)
	/go/pkg/mod/github.com/palantir/go-githubapp@v0.38.0/githubapp/middleware.go:64 +0x124
github.com/palantir/go-githubapp/githubapp.roundTripperFunc.RoundTrip(0xc00026c3c0, 0xc000276500)
	/go/pkg/mod/github.com/palantir/go-githubapp@v0.38.0/githubapp/middleware.go:121 +0x34
github.com/palantir/go-githubapp/githubapp.(*clientCreator).newClient.setInstallationID.func1.1(0xc0002763c0)
	/go/pkg/mod/github.com/palantir/go-githubapp@v0.38.0/githubapp/client_creator.go:426 +0xa8
github.com/palantir/go-githubapp/githubapp.roundTripperFunc.RoundTrip(0xc00004c520, 0xc0002763c0)
	/go/pkg/mod/github.com/palantir/go-githubapp@v0.38.0/githubapp/middleware.go:121 +0x34
net/http.send(0xc000276280, {0x11f21c0, 0xc00004c520}, {0x8?, 0x8?, 0x17606e0?})
	/usr/local/go/src/net/http/client.go:259 +0x8cb
net/http.(*Client).send(0xc00026c420, 0xc000276280, {0x0?, 0x633e54?, 0x17606e0?})
	/usr/local/go/src/net/http/client.go:180 +0x14d
net/http.(*Client).do(0xc00026c420, 0xc000276280)
	/usr/local/go/src/net/http/client.go:728 +0x1339
net/http.(*Client).Do(...)
	/usr/local/go/src/net/http/client.go:587
github.com/google/go-github/v74/github.(*Client).bareDo(0xc000550008, {0x11f7a78, 0x1782240}, 0xc00026c420, 0xc000276140)
	/go/pkg/mod/github.com/google/go-github/v74@v74.0.0/github/github.go:881 +0x4a8
github.com/google/go-github/v74/github.(*Client).BareDo(...)
	/go/pkg/mod/github.com/google/go-github/v74@v74.0.0/github/github.go:968
github.com/google/go-github/v74/github.(*Client).Do(0xc000550008, {0x11f7a78, 0x1782240}, 0xc000276140, {0xf2ee60, 0xc0004b0108})
	/go/pkg/mod/github.com/google/go-github/v74@v74.0.0/github/github.go:1036 +0xae
github.com/google/go-github/v74/github.(*PullRequestsService).List(0xc000550338, {0x11f7a78, 0x1782240}, {0xc00049a5b5, 0xb}, {0xc00049a5f7, 0x9}, 0xc000188c60)
	/go/pkg/mod/github.com/google/go-github/v74@v74.0.0/github/pulls.go:164 +0x23e
github.com/sourcectl/worker/consumer.(*GithubRepositoryPullRequestsConsumer).Start(0xc0000b35f0)
	/build/consumer/consumer_github_repository_pullrequests.go:177 +0x133d
github.com/sourcectl/worker/cmd.cmdGithubWorker.func4()
	/build/cmd/github_worker.go:177 +0x43
created by github.com/sourcectl/worker/cmd.cmdGithubWorker in goroutine 1
	/build/cmd/github_worker.go:176 +0x1aa5
	```