### PR TITLE
Drop dependency on github.com/pkg/errors

### DIFF
--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -20,13 +20,13 @@ package appconfig
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/google/go-github/v85/github"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
 
@@ -52,7 +52,7 @@ type RemoteRef struct {
 func (r RemoteRef) SplitRemote() (owner, repo string, err error) {
 	slash := strings.IndexByte(r.Remote, '/')
 	if slash <= 0 || slash >= len(r.Remote)-1 {
-		return "", "", errors.Errorf("invalid remote value: %s", r.Remote)
+		return "", "", fmt.Errorf("invalid remote value: %s", r.Remote)
 	}
 	return r.Remote[:slash], r.Remote[slash+1:], nil
 }
@@ -189,7 +189,7 @@ func (ld *Loader) loadRemoteConfig(ctx context.Context, client *github.Client, r
 			if isNotFound(err) {
 				return c, notFoundErr
 			}
-			return c, errors.Wrap(err, "failed to get remote repository")
+			return c, fmt.Errorf("failed to get remote repository: %w", err)
 		}
 		ref = r.GetDefaultBranch()
 	}
@@ -222,7 +222,7 @@ func (ld *Loader) loadDefaultConfig(ctx context.Context, client *github.Client, 
 			return Config{}, nil
 		}
 		c := Config{Source: fmt.Sprintf("%s/%s", owner, ld.defaultRepo)}
-		return c, errors.Wrap(err, "failed to get default repository")
+		return c, fmt.Errorf("failed to get default repository: %w", err)
 	}
 
 	ref := r.GetDefaultBranch()
@@ -278,7 +278,7 @@ func getFileContents(ctx context.Context, client *github.Client, owner, repo, re
 		if isNotFound(err) {
 			return nil, false, nil
 		}
-		return nil, false, errors.Wrap(err, "failed to read file")
+		return nil, false, fmt.Errorf("failed to read file: %w", err)
 	}
 
 	// The file will be nil if the path exists but is a directory
@@ -300,12 +300,12 @@ func getFileContents(ctx context.Context, client *github.Client, owner, repo, re
 
 	req, err := http.NewRequestWithContext(ctx, "GET", downloadURL, nil)
 	if err != nil {
-		return nil, true, errors.Wrap(err, "failed to create download request")
+		return nil, true, fmt.Errorf("failed to create download request: %w", err)
 	}
 
 	res, err := client.Client().Do(req)
 	if err != nil {
-		return nil, true, errors.Wrap(err, "failed to download file")
+		return nil, true, fmt.Errorf("failed to download file: %w", err)
 	}
 
 	defer func() {
@@ -314,12 +314,12 @@ func getFileContents(ctx context.Context, client *github.Client, owner, repo, re
 	}()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, true, errors.Errorf("failed to download file: unexpected status code %d", res.StatusCode)
+		return nil, true, fmt.Errorf("failed to download file: unexpected status code %d", res.StatusCode)
 	}
 
 	b, err := io.ReadAll(res.Body)
 	if err != nil {
-		return nil, true, errors.Wrap(err, "failed to read file")
+		return nil, true, fmt.Errorf("failed to read file: %w", err)
 	}
 	return b, true, nil
 }

--- a/appconfig/responseplayer_test.go
+++ b/appconfig/responseplayer_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -55,12 +54,12 @@ func (rp *ResponsePlayer) AddRule(matcher RequestMatcher, file string) *Rule {
 
 	d, err := os.ReadFile(file)
 	if err != nil {
-		rule.err = errors.Wrapf(err, "failed to read response file: %s", file)
+		rule.err = fmt.Errorf("failed to read response file: %s: %w", file, err)
 		return rule
 	}
 
 	if err := yaml.Unmarshal(d, &rule.responses); err != nil {
-		rule.err = errors.Wrapf(err, "failed to unmarshal response file: %s", file)
+		rule.err = fmt.Errorf("failed to unmarshal response file: %s: %w", file, err)
 		return rule
 	}
 

--- a/example/config.go
+++ b/example/config.go
@@ -15,10 +15,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/palantir/go-githubapp/githubapp"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
@@ -43,11 +43,11 @@ func ReadConfig(path string) (*Config, error) {
 
 	bytes, err := os.ReadFile(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed reading server config file: %s", path)
+		return nil, fmt.Errorf("failed reading server config file: %s: %w", path, err)
 	}
 
 	if err := yaml.UnmarshalStrict(bytes, &c); err != nil {
-		return nil, errors.Wrap(err, "failed parsing configuration file")
+		return nil, fmt.Errorf("failed parsing configuration file: %w", err)
 	}
 
 	return &c, nil

--- a/example/issue_comment.go
+++ b/example/issue_comment.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-github/v85/github"
 	"github.com/palantir/go-githubapp/githubapp"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
 
@@ -39,7 +38,7 @@ func (h *PRCommentHandler) Handles() []string {
 func (h *PRCommentHandler) Handle(ctx context.Context, eventType, deliveryID string, payload []byte) error {
 	var event github.IssueCommentEvent
 	if err := json.Unmarshal(payload, &event); err != nil {
-		return errors.Wrap(err, "failed to parse issue comment event payload")
+		return fmt.Errorf("failed to parse issue comment event payload: %w", err)
 	}
 
 	if !event.GetIssue().IsPullRequest() {

--- a/githubapp/caching_client_creator.go
+++ b/githubapp/caching_client_creator.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/google/go-github/v85/github"
 	lru "github.com/hashicorp/golang-lru"
-	"github.com/pkg/errors"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
@@ -47,7 +46,7 @@ func NewDefaultCachingClientCreator(c Config, opts ...ClientOption) (ClientCreat
 func NewCachingClientCreator(delegate ClientCreator, capacity int) (ClientCreator, error) {
 	cache, err := lru.New(capacity)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create cache")
+		return nil, fmt.Errorf("failed to create cache: %w", err)
 	}
 
 	return &cachingClientCreator{

--- a/githubapp/client_creator.go
+++ b/githubapp/client_creator.go
@@ -26,7 +26,6 @@ import (
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	"github.com/google/go-github/v85/github"
 	"github.com/gregjones/httpcache"
-	"github.com/pkg/errors"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
@@ -313,7 +312,7 @@ func (c *clientCreator) newClient(base *http.Client, middleware []ClientMiddlewa
 
 	baseURL, err := url.Parse(c.v3BaseURL)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse base URL: %q", c.v3BaseURL)
+		return nil, fmt.Errorf("failed to parse base URL: %q: %w", c.v3BaseURL, err)
 	}
 
 	client := github.NewClient(base)
@@ -332,7 +331,7 @@ func (c *clientCreator) newV4Client(base *http.Client, middleware []ClientMiddle
 
 	v4BaseURL, err := url.Parse(c.v4BaseURL)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse base URL: %q", c.v4BaseURL)
+		return nil, fmt.Errorf("failed to parse base URL: %q: %w", c.v4BaseURL, err)
 	}
 
 	client := githubv4.NewEnterpriseClient(v4BaseURL.String(), base)

--- a/githubapp/dispatcher.go
+++ b/githubapp/dispatcher.go
@@ -16,11 +16,11 @@ package githubapp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/google/go-github/v85/github"
-	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 	"github.com/rs/zerolog"
 )

--- a/githubapp/installations.go
+++ b/githubapp/installations.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 
 	"github.com/google/go-github/v85/github"
-	"github.com/pkg/errors"
 )
 
 // Installation is a minimal representation of a GitHub app installation.
@@ -94,7 +93,7 @@ func (i defaultInstallationsService) ListAll(ctx context.Context) ([]Installatio
 	for {
 		installations, res, err := i.Apps.ListInstallations(ctx, &opt)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to list installations")
+			return nil, fmt.Errorf("failed to list installations: %w", err)
 		}
 		for _, inst := range installations {
 			allInstallations = append(allInstallations, toInstallation(inst))
@@ -125,7 +124,7 @@ func (i defaultInstallationsService) GetByOwner(ctx context.Context, owner strin
 	if isNotFound(err) {
 		return Installation{}, InstallationNotFound(owner)
 	}
-	return Installation{}, errors.Wrapf(err, "failed to get installation for owner %q", owner)
+	return Installation{}, fmt.Errorf("failed to get installation for owner %q: %w", owner, err)
 }
 
 func (i defaultInstallationsService) GetByRepository(ctx context.Context, owner, repo string) (Installation, error) {
@@ -138,7 +137,7 @@ func (i defaultInstallationsService) GetByRepository(ctx context.Context, owner,
 	if isNotFound(err) {
 		return Installation{}, InstallationNotFound(ownerRepo)
 	}
-	return Installation{}, errors.Wrapf(err, "failed to get installation for repository %q", ownerRepo)
+	return Installation{}, fmt.Errorf("failed to get installation for repository %q: %w", ownerRepo, err)
 }
 
 // InstallationNotFound is returned when no installation exists for a

--- a/githubapp/scheduler.go
+++ b/githubapp/scheduler.go
@@ -16,10 +16,10 @@ package githubapp
 
 import (
 	"context"
+	"errors"
 	"sync/atomic"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 	"github.com/rs/zerolog"
 )

--- a/githubapp/scheduler_test.go
+++ b/githubapp/scheduler_test.go
@@ -16,10 +16,9 @@ package githubapp
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 type AsyncHandler struct {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/pkg/errors v0.9.1
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9
 	github.com/rs/zerolog v1.35.1
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,6 @@ github.com/mattn/go-isatty v0.0.22/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJ
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 h1:bsUq1dX0N8AOIL7EB/X911+m4EHsnWEHeJ0c+3TTBrg=
 github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/oauth2/sessions.go
+++ b/oauth2/sessions.go
@@ -18,10 +18,10 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 
 	"github.com/alexedwards/scs"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -37,7 +37,7 @@ func (s *SessionStateStore) GenerateState(w http.ResponseWriter, r *http.Request
 
 	b := make([]byte, 20)
 	if _, err := rand.Read(b); err != nil {
-		return "", errors.Wrap(err, "failed to generate state value")
+		return "", fmt.Errorf("failed to generate state value: %w", err)
 	}
 
 	state := hex.EncodeToString(b)


### PR DESCRIPTION
## Before this PR

The project depended on `github.com/pkg/errors` for wrapping and formatting errors. This adds an extra external dependency for functionality that modern Go provides in the standard library. Keeping it also increases maintenance surface and dependency churn.

## After this PR

All usages of `github.com/pkg/errors` were replaced with standard-library error handling (`fmt.Errorf("...: %w", err)` and `errors` where needed), and the module dependency was removed from go.mod.

==COMMIT_MSG==
Drop dependency on github.com/pkg/errors
==COMMIT_MSG==

## Possible downsides?

- If anyone relied on `pkg/errors` stack-trace formatting (for example, `%+v` behavior), that detail is no longer available from newly wrapped errors.
- Error message text changed slightly in some places, which could affect brittle string-matching tests or log parsers.
