### PR TITLE
Make OAuth authorization URL configurable for GHES 3.18+

### DIFF
--- a/githubapp/config.go
+++ b/githubapp/config.go
@@ -33,6 +33,11 @@ type Config struct {
 	OAuth struct {
 		ClientID     string `yaml:"client_id" json:"clientId"`
 		ClientSecret string `yaml:"client_secret" json:"clientSecret"`
+		// AuthURL overrides the OAuth authorization endpoint URL. When empty,
+		// the URL is derived from WebURL using the default GitHub path
+		// (/login/oauth/authorize). Set this for GitHub Enterprise Server 3.18+
+		// deployments where the endpoint is /login/oauth/authorize_app.
+		AuthURL string `yaml:"auth_url" json:"authUrl"`
 	} `yaml:"oauth" json:"oauth"`
 }
 
@@ -50,6 +55,7 @@ func (c *Config) SetValuesFromEnv(prefix string) {
 
 	setStringFromEnv("GITHUB_OAUTH_CLIENT_ID", prefix, &c.OAuth.ClientID)
 	setStringFromEnv("GITHUB_OAUTH_CLIENT_SECRET", prefix, &c.OAuth.ClientSecret)
+	setStringFromEnv("GITHUB_OAUTH_AUTH_URL", prefix, &c.OAuth.AuthURL)
 }
 
 func setStringFromEnv(key, prefix string, value *string) {

--- a/oauth2/github.go
+++ b/oauth2/github.go
@@ -25,12 +25,19 @@ const (
 	DefaultRoute = "/api/github/auth"
 )
 
+const defaultAuthPath = "/login/oauth/authorize"
+
 func GetConfig(c githubapp.Config, scopes []string) *oauth2.Config {
+	authURL := c.OAuth.AuthURL
+	if authURL == "" {
+		authURL = joinURL(c.WebURL, defaultAuthPath)
+	}
+
 	return &oauth2.Config{
 		ClientID:     c.OAuth.ClientID,
 		ClientSecret: c.OAuth.ClientSecret,
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  joinURL(c.WebURL, "/login/oauth/authorize"),
+			AuthURL:  authURL,
 			TokenURL: joinURL(c.WebURL, "/login/oauth/access_token"),
 		},
 		Scopes: scopes,


### PR DESCRIPTION
## Problem

`oauth2.GetConfig` always builds the OAuth `AuthURL` by joining `WebURL` with the hard-coded path `/login/oauth/authorize`. GitHub Enterprise Server 3.18 moved the authorization endpoint to `/login/oauth/authorize_app`, so callers targeting a GHES 3.18+ instance get an incorrect redirect URL with no way to override it short of forking the package or wrapping the returned `*oauth2.Config` after the fact.

## Solution

Add an optional `auth_url` field to the `oauth` block of `githubapp.Config`. When the field is non-empty, `GetConfig` uses it directly as the OAuth `AuthURL`; when it is empty, the current default behaviour (`joinURL(c.WebURL, "/login/oauth/authorize")`) is preserved, so there is no behavior change for existing deployments.

The field can also be supplied via the `GITHUB_OAUTH_AUTH_URL` environment variable, consistent with how the other OAuth fields are handled.

**GHES 3.18+ example config:**
```yaml
github:
  web_url: "https://github.example.com"
  oauth:
    client_id: "..."
    client_secret: "..."
    auth_url: "https://github.example.com/login/oauth/authorize_app"
```

## Changes

- `githubapp/config.go`: add `AuthURL string` field to the `OAuth` sub-struct; read it from `GITHUB_OAUTH_AUTH_URL` in `SetValuesFromEnv`
- `oauth2/github.go`: use `c.OAuth.AuthURL` when non-empty, otherwise fall back to the default path

Fixes #558