### PR TITLE
feat: enable logging of github request ID

### DIFF
--- a/githubapp/middleware_logging.go
+++ b/githubapp/middleware_logging.go
@@ -32,6 +32,7 @@ const (
 	httpHeaderRateUsed      = "X-Ratelimit-Used"
 	httpHeaderRateReset     = "X-Ratelimit-Reset"
 	httpHeaderRateResource  = "X-Ratelimit-Resource"
+	httpHeaderRequestID     = "X-GitHub-Request-Id"
 )
 
 // ClientLogging creates client middleware that logs request and response
@@ -73,6 +74,9 @@ func ClientLogging(lvl zerolog.Level, opts ...ClientLoggingOption) ClientMiddlew
 				cached := res.Header.Get(httpcache.XFromCache) != ""
 				evt.Bool("cached", cached).
 					Int("status", res.StatusCode)
+				if requestID := res.Header.Get(httpHeaderRequestID); requestID != "" {
+					evt.Str("github_request_id", requestID)
+				}
 
 				size := res.ContentLength
 				if requestMatches(r, options.ResponseBodyPatterns) {


### PR DESCRIPTION
## Before this PR
Structured `github_request` logs do not include GitHub’s request ID, making it more difficult to diagnose failures involving the GitHub API.

## After this PR
==COMMIT_MSG==
GitHub request IDs are now included in GitHub client logs.
==COMMIT_MSG==

## Possible downsides?
More verbose logs?

This PR originated out of [this discussion](https://github.com/palantir/policy-bot/issues/1333).