### PR TITLE
feat: make github request ID logging opt-in

### DIFF
--- a/githubapp/middleware_logging.go
+++ b/githubapp/middleware_logging.go
@@ -74,7 +74,7 @@ func ClientLogging(lvl zerolog.Level, opts ...ClientLoggingOption) ClientMiddlew
 				cached := res.Header.Get(httpcache.XFromCache) != ""
 				evt.Bool("cached", cached).
 					Int("status", res.StatusCode)
-				if requestID := res.Header.Get(httpHeaderRequestID); requestID != "" {
+				if requestID := res.Header.Get(httpHeaderRequestID); options.LogGitHubRequestID && requestID != "" {
 					evt.Str("github_request_id", requestID)
 				}
 
@@ -113,6 +113,7 @@ type clientLoggingOptions struct {
 
 	// Output control
 	LogRateLimitInformation *RateLimitLoggingOption
+	LogGitHubRequestID      bool
 }
 
 // RateLimitLoggingOption controls which rate limit information is logged.
@@ -149,6 +150,13 @@ func LogResponseBody(patterns ...string) ClientLoggingOption {
 func LogRateLimitInformation(options *RateLimitLoggingOption) ClientLoggingOption {
 	return func(opts *clientLoggingOptions) {
 		opts.LogRateLimitInformation = options
+	}
+}
+
+// LogGitHubRequestID enables logging of the request ID returned by GitHub.
+func LogGitHubRequestID() ClientLoggingOption {
+	return func(opts *clientLoggingOptions) {
+		opts.LogGitHubRequestID = true
 	}
 }
 


### PR DESCRIPTION
## Before this PR
GitHub request IDs are always included in client logs, giving users no control over the additional log volume.

## After this PR
==COMMIT_MSG==
GitHub request ID logging is now enabled with the `LogGitHubRequestID` client logging option.
==COMMIT_MSG==

## Possible downsides?
Request ID logging now requires explicit opt-in.

Follow-up to https://github.com/palantir/go-githubapp/pull/601.