### PR TITLE
feat(appconfig): support private cross-owner appconfig remotes

### DIFF
--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v90/github"
+	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/rs/zerolog"
 )
 
@@ -81,6 +82,9 @@ type Loader struct {
 	parser       RemoteRefParser
 	defaultRepo  string
 	defaultPaths []string
+
+	clientCreator githubapp.ClientCreator
+	installations githubapp.InstallationsService
 }
 
 // NewLoader creates a Loader that loads configuration from paths.
@@ -139,7 +143,7 @@ func (ld *Loader) LoadConfig(ctx context.Context, client *github.Client, owner, 
 			}
 			if remote != nil {
 				logger.Debug().Msgf("Found remote configuration at %s in %s", p, c.Source)
-				return ld.loadRemoteConfig(ctx, client, *remote, c)
+				return ld.loadRemoteConfig(ctx, client, owner, *remote, c)
 			}
 		}
 
@@ -159,7 +163,7 @@ func (ld *Loader) LoadConfig(ctx context.Context, client *github.Client, owner, 
 	return Config{}, nil
 }
 
-func (ld *Loader) loadRemoteConfig(ctx context.Context, client *github.Client, remote RemoteRef, c Config) (Config, error) {
+func (ld *Loader) loadRemoteConfig(ctx context.Context, client *github.Client, sourceOwner string, remote RemoteRef, c Config) (Config, error) {
 	logger := zerolog.Ctx(ctx)
 	notFoundErr := fmt.Errorf("invalid remote reference: file does not exist")
 
@@ -167,6 +171,7 @@ func (ld *Loader) loadRemoteConfig(ctx context.Context, client *github.Client, r
 	if err != nil {
 		return c, err
 	}
+	client = ld.remoteClient(ctx, client, sourceOwner, owner)
 
 	path := remote.Path
 	if path == "" && len(ld.paths) > 0 {
@@ -250,7 +255,7 @@ func (ld *Loader) loadDefaultConfig(ctx context.Context, client *github.Client, 
 			}
 			if remote != nil {
 				logger.Debug().Msgf("Found remote default configuration at %s in %s", p, c.Source)
-				return ld.loadRemoteConfig(ctx, client, *remote, c)
+				return ld.loadRemoteConfig(ctx, client, owner, *remote, c)
 			}
 		}
 
@@ -262,6 +267,30 @@ func (ld *Loader) loadDefaultConfig(ctx context.Context, client *github.Client, 
 
 	// no default configuration, return an empty/undefined one
 	return Config{}, nil
+}
+
+// remoteClient returns an installation-scoped client for remoteOwner when
+// private remotes are enabled and the remote belongs to a different owner. If
+// the app is not installed on that owner, or a client cannot be created, it
+// falls back to the caller's client so public repositories continue to work.
+func (ld *Loader) remoteClient(ctx context.Context, client *github.Client, sourceOwner, remoteOwner string) *github.Client {
+	if strings.EqualFold(sourceOwner, remoteOwner) || ld.clientCreator == nil || ld.installations == nil {
+		return client
+	}
+
+	logger := zerolog.Ctx(ctx)
+	installation, err := ld.installations.GetByOwner(ctx, remoteOwner)
+	if err != nil {
+		logger.Warn().Err(err).Msgf("Failed to find GitHub App installation for remote configuration owner %q; using the original client", remoteOwner)
+		return client
+	}
+
+	remoteClient, err := ld.clientCreator.NewInstallationClient(installation.ID)
+	if err != nil {
+		logger.Warn().Err(err).Msgf("Failed to create GitHub App client for remote configuration owner %q; using the original client", remoteOwner)
+		return client
+	}
+	return remoteClient
 }
 
 // getFileContents returns the content of the file at path on ref in owner/repo

--- a/appconfig/appconfig.go
+++ b/appconfig/appconfig.go
@@ -171,7 +171,7 @@ func (ld *Loader) loadRemoteConfig(ctx context.Context, client *github.Client, s
 	if err != nil {
 		return c, err
 	}
-	client = ld.remoteClient(ctx, client, sourceOwner, owner)
+	client = ld.remoteClient(ctx, client, sourceOwner, owner, repo)
 
 	path := remote.Path
 	if path == "" && len(ld.paths) > 0 {
@@ -269,25 +269,25 @@ func (ld *Loader) loadDefaultConfig(ctx context.Context, client *github.Client, 
 	return Config{}, nil
 }
 
-// remoteClient returns an installation-scoped client for remoteOwner when
+// remoteClient returns an installation-scoped client for remoteOwner/remoteRepo when
 // private remotes are enabled and the remote belongs to a different owner. If
-// the app is not installed on that owner, or a client cannot be created, it
+// the app is not installed on that repository, or a client cannot be created, it
 // falls back to the caller's client so public repositories continue to work.
-func (ld *Loader) remoteClient(ctx context.Context, client *github.Client, sourceOwner, remoteOwner string) *github.Client {
+func (ld *Loader) remoteClient(ctx context.Context, client *github.Client, sourceOwner, remoteOwner, remoteRepo string) *github.Client {
 	if strings.EqualFold(sourceOwner, remoteOwner) || ld.clientCreator == nil || ld.installations == nil {
 		return client
 	}
 
 	logger := zerolog.Ctx(ctx)
-	installation, err := ld.installations.GetByOwner(ctx, remoteOwner)
+	installation, err := ld.installations.GetByRepository(ctx, remoteOwner, remoteRepo)
 	if err != nil {
-		logger.Warn().Err(err).Msgf("Failed to find GitHub App installation for remote configuration owner %q; using the original client", remoteOwner)
+		logger.Warn().Err(err).Msgf("Failed to find GitHub App installation for remote configuration repository %q; using the original client", remoteOwner+"/"+remoteRepo)
 		return client
 	}
 
 	remoteClient, err := ld.clientCreator.NewInstallationClient(installation.ID)
 	if err != nil {
-		logger.Warn().Err(err).Msgf("Failed to create GitHub App client for remote configuration owner %q; using the original client", remoteOwner)
+		logger.Warn().Err(err).Msgf("Failed to create GitHub App client for remote configuration repository %q; using the original client", remoteOwner+"/"+remoteRepo)
 		return client
 	}
 	return remoteClient

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/google/go-github/v90/github"
 	"github.com/palantir/go-githubapp/githubapp"
-	"github.com/shurcooL/githubv4"
-	"golang.org/x/oauth2"
 )
 
 const (
@@ -34,57 +32,38 @@ const (
 )
 
 type testInstallationsService struct {
+	githubapp.InstallationsService
+
 	installation githubapp.Installation
 	err          error
 	calls        int
+	owner        string
+	repo         string
 }
 
-func (s *testInstallationsService) ListAll(context.Context) ([]githubapp.Installation, error) {
-	return nil, errors.New("not implemented")
-}
-
-func (s *testInstallationsService) GetByOwner(context.Context, string) (githubapp.Installation, error) {
+func (s *testInstallationsService) GetByRepository(_ context.Context, owner, repo string) (githubapp.Installation, error) {
 	s.calls++
+	s.owner = owner
+	s.repo = repo
 	if s.err != nil {
 		return githubapp.Installation{}, s.err
 	}
 	return s.installation, nil
 }
 
-func (s *testInstallationsService) GetByRepository(context.Context, string, string) (githubapp.Installation, error) {
-	return githubapp.Installation{}, errors.New("not implemented")
-}
-
 type testClientCreator struct {
-	client *github.Client
-	err    error
-	calls  int
+	githubapp.ClientCreator
+
+	client         *github.Client
+	err            error
+	calls          int
+	installationID int64
 }
 
-func (c *testClientCreator) NewAppClient() (*github.Client, error) {
-	return nil, errors.New("not implemented")
-}
-func (c *testClientCreator) NewAppV4Client() (*githubv4.Client, error) {
-	return nil, errors.New("not implemented")
-}
-func (c *testClientCreator) NewInstallationClient(int64) (*github.Client, error) {
+func (c *testClientCreator) NewInstallationClient(installationID int64) (*github.Client, error) {
 	c.calls++
+	c.installationID = installationID
 	return c.client, c.err
-}
-func (c *testClientCreator) NewInstallationV4Client(int64) (*githubv4.Client, error) {
-	return nil, errors.New("not implemented")
-}
-func (c *testClientCreator) NewTokenSourceClient(oauth2.TokenSource) (*github.Client, error) {
-	return nil, errors.New("not implemented")
-}
-func (c *testClientCreator) NewTokenSourceV4Client(oauth2.TokenSource) (*githubv4.Client, error) {
-	return nil, errors.New("not implemented")
-}
-func (c *testClientCreator) NewTokenClient(string) (*github.Client, error) {
-	return nil, errors.New("not implemented")
-}
-func (c *testClientCreator) NewTokenV4Client(string) (*githubv4.Client, error) {
-	return nil, errors.New("not implemented")
 }
 
 func TestLoadConfig(t *testing.T) {
@@ -214,7 +193,7 @@ func TestLoadConfigWithPrivateRemotes(t *testing.T) {
 		return rp
 	}
 
-	t.Run("uses remote owner installation client", func(t *testing.T) {
+	t.Run("uses remote repository installation client", func(t *testing.T) {
 		localRules := localRules(false)
 		remoteRules := &ResponsePlayer{}
 		remoteRule := remoteRules.AddRule(ExactPathMatcher("/repos/remote/config/contents/config/test-app.yml"), filepath.Join("testdata", "config-contents.yml"))
@@ -232,14 +211,20 @@ func TestLoadConfigWithPrivateRemotes(t *testing.T) {
 		if installations.calls != 1 || creator.calls != 1 || remoteRule.Count != 1 {
 			t.Errorf("expected one installation lookup, client creation, and remote request; got %d, %d, and %d", installations.calls, creator.calls, remoteRule.Count)
 		}
+		if installations.owner != "remote" || installations.repo != "config" {
+			t.Errorf("expected installation lookup for remote/config, got %s/%s", installations.owner, installations.repo)
+		}
+		if creator.installationID != 42 {
+			t.Errorf("expected installation client for ID 42, got %d", creator.installationID)
+		}
 	})
 
 	for name, test := range map[string]struct {
 		installationsErr error
 		creatorErr       error
 	}{
-		"falls back when remote owner has no installation":   {installationsErr: githubapp.InstallationNotFound("remote")},
-		"falls back when installation client creation fails": {creatorErr: errors.New("client creation failed")},
+		"falls back when remote repository has no installation": {installationsErr: githubapp.InstallationNotFound("remote/config")},
+		"falls back when installation client creation fails":    {creatorErr: errors.New("client creation failed")},
 	} {
 		t.Run(name, func(t *testing.T) {
 			localRules := localRules(true)
@@ -270,7 +255,7 @@ func TestPrivateRemotesSameOwnerReusesOriginalClient(t *testing.T) {
 	creator := &testClientCreator{}
 	loader := NewLoader(nil, WithPrivateRemotes(creator, installations))
 
-	got := loader.remoteClient(context.Background(), client, "Source-Owner", "source-owner")
+	got := loader.remoteClient(context.Background(), client, "Source-Owner", "source-owner", "config")
 	if got != client {
 		t.Error("same-owner remote did not reuse the original client")
 	}

--- a/appconfig/appconfig_test.go
+++ b/appconfig/appconfig_test.go
@@ -17,17 +17,75 @@ package appconfig
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"path/filepath"
 	"testing"
 
 	"github.com/google/go-github/v90/github"
+	"github.com/palantir/go-githubapp/githubapp"
+	"github.com/shurcooL/githubv4"
+	"golang.org/x/oauth2"
 )
 
 const (
 	TestOwner = "test"
 	TestRef   = "develop"
 )
+
+type testInstallationsService struct {
+	installation githubapp.Installation
+	err          error
+	calls        int
+}
+
+func (s *testInstallationsService) ListAll(context.Context) ([]githubapp.Installation, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *testInstallationsService) GetByOwner(context.Context, string) (githubapp.Installation, error) {
+	s.calls++
+	if s.err != nil {
+		return githubapp.Installation{}, s.err
+	}
+	return s.installation, nil
+}
+
+func (s *testInstallationsService) GetByRepository(context.Context, string, string) (githubapp.Installation, error) {
+	return githubapp.Installation{}, errors.New("not implemented")
+}
+
+type testClientCreator struct {
+	client *github.Client
+	err    error
+	calls  int
+}
+
+func (c *testClientCreator) NewAppClient() (*github.Client, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *testClientCreator) NewAppV4Client() (*githubv4.Client, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *testClientCreator) NewInstallationClient(int64) (*github.Client, error) {
+	c.calls++
+	return c.client, c.err
+}
+func (c *testClientCreator) NewInstallationV4Client(int64) (*githubv4.Client, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *testClientCreator) NewTokenSourceClient(oauth2.TokenSource) (*github.Client, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *testClientCreator) NewTokenSourceV4Client(oauth2.TokenSource) (*githubv4.Client, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *testClientCreator) NewTokenClient(string) (*github.Client, error) {
+	return nil, errors.New("not implemented")
+}
+func (c *testClientCreator) NewTokenV4Client(string) (*githubv4.Client, error) {
+	return nil, errors.New("not implemented")
+}
 
 func TestLoadConfig(t *testing.T) {
 	tests := map[string]struct {
@@ -139,6 +197,85 @@ func TestLoadConfig(t *testing.T) {
 				t.Errorf("incorrect content\nexpected: %s\n  actual: %s", test.Expected.Content, cfg.Content)
 			}
 		})
+	}
+}
+
+func TestLoadConfigWithPrivateRemotes(t *testing.T) {
+	newClient := func(rp *ResponsePlayer) *github.Client {
+		client, _ := github.NewClient(github.WithHTTPClient(&http.Client{Transport: rp}))
+		return client
+	}
+	localRules := func(includeRemote bool) *ResponsePlayer {
+		rp := &ResponsePlayer{}
+		rp.AddRule(ExactPathMatcher("/repos/test/remote-ref/contents/.github/test-app.yml"), filepath.Join("testdata", "remote-ref-contents.yml"))
+		if includeRemote {
+			rp.AddRule(ExactPathMatcher("/repos/remote/config/contents/config/test-app.yml"), filepath.Join("testdata", "config-contents.yml"))
+		}
+		return rp
+	}
+
+	t.Run("uses remote owner installation client", func(t *testing.T) {
+		localRules := localRules(false)
+		remoteRules := &ResponsePlayer{}
+		remoteRule := remoteRules.AddRule(ExactPathMatcher("/repos/remote/config/contents/config/test-app.yml"), filepath.Join("testdata", "config-contents.yml"))
+		installations := &testInstallationsService{installation: githubapp.Installation{ID: 42, Owner: "remote"}}
+		creator := &testClientCreator{client: newClient(remoteRules)}
+
+		loader := NewLoader([]string{".github/test-app.yml"}, WithPrivateRemotes(creator, installations))
+		cfg, err := loader.LoadConfig(context.Background(), newClient(localRules), TestOwner, "remote-ref", TestRef)
+		if err != nil {
+			t.Fatalf("unexpected error loading config: %v", err)
+		}
+		if !bytes.Equal(cfg.Content, []byte("message: hello\n")) {
+			t.Errorf("incorrect content: %s", cfg.Content)
+		}
+		if installations.calls != 1 || creator.calls != 1 || remoteRule.Count != 1 {
+			t.Errorf("expected one installation lookup, client creation, and remote request; got %d, %d, and %d", installations.calls, creator.calls, remoteRule.Count)
+		}
+	})
+
+	for name, test := range map[string]struct {
+		installationsErr error
+		creatorErr       error
+	}{
+		"falls back when remote owner has no installation":   {installationsErr: githubapp.InstallationNotFound("remote")},
+		"falls back when installation client creation fails": {creatorErr: errors.New("client creation failed")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			localRules := localRules(true)
+			installations := &testInstallationsService{installation: githubapp.Installation{ID: 42, Owner: "remote"}, err: test.installationsErr}
+			creator := &testClientCreator{err: test.creatorErr}
+
+			loader := NewLoader([]string{".github/test-app.yml"}, WithPrivateRemotes(creator, installations))
+			cfg, err := loader.LoadConfig(context.Background(), newClient(localRules), TestOwner, "remote-ref", TestRef)
+			if err != nil {
+				t.Fatalf("unexpected error loading config: %v", err)
+			}
+			if !bytes.Equal(cfg.Content, []byte("message: hello\n")) {
+				t.Errorf("incorrect content: %s", cfg.Content)
+			}
+			if test.installationsErr != nil && creator.calls != 0 {
+				t.Errorf("client creator was called after installation lookup failed")
+			}
+			if test.creatorErr != nil && creator.calls != 1 {
+				t.Errorf("expected one client creation attempt, got %d", creator.calls)
+			}
+		})
+	}
+}
+
+func TestPrivateRemotesSameOwnerReusesOriginalClient(t *testing.T) {
+	client := makeTestClient()
+	installations := &testInstallationsService{}
+	creator := &testClientCreator{}
+	loader := NewLoader(nil, WithPrivateRemotes(creator, installations))
+
+	got := loader.remoteClient(context.Background(), client, "Source-Owner", "source-owner")
+	if got != client {
+		t.Error("same-owner remote did not reuse the original client")
+	}
+	if installations.calls != 0 || creator.calls != 0 {
+		t.Errorf("same-owner remote attempted installation lookup or client creation: %d, %d", installations.calls, creator.calls)
 	}
 }
 

--- a/appconfig/options.go
+++ b/appconfig/options.go
@@ -14,6 +14,8 @@
 
 package appconfig
 
+import "github.com/palantir/go-githubapp/githubapp"
+
 type Option func(*Loader)
 
 // WithRemoteRefParser sets the parser for encoded RemoteRefs. The default
@@ -36,20 +38,19 @@ func WithOwnerDefault(name string, paths []string) Option {
 	}
 }
 
-/*
-
-Not sure this is valuable yet, but leaving this option function as a starting
-point for a future implementation. See https://github.com/palantir/policy-bot/issues/111
-for some explanation of why this is desired.
-
-In the Loader implementation, if a ClientCreator and InstallationsService are
-set, the loadRemoteConfig method would use them to create a new client if the
-remote owner does not equal the starting owner.
-
 // WithPrivateRemotes enables loading remote configuration from private
-// repositories in different organizations. By default, only public
-// repositories can be remote targets.
-func WithPrivateRemotes(cc githubapp.ClientCreator, installs githubapp.InstallationsService) Option {
-	return func(ld *Loader) {}
+// repositories owned by a different user or organization. It uses the app's
+// installation on the remote owner to fetch the referenced file. If the app
+// is not installed on that owner, or an installation client cannot be created,
+// the loader logs the failure and falls back to the original client so public
+// remote repositories remain supported.
+//
+// This loader does not cache installation lookups or clients. Callers that
+// load configuration frequently should pass caching implementations, such as
+// githubapp.NewCachingInstallationsService and githubapp.NewCachingClientCreator.
+func WithPrivateRemotes(clientCreator githubapp.ClientCreator, installations githubapp.InstallationsService) Option {
+	return func(ld *Loader) {
+		ld.clientCreator = clientCreator
+		ld.installations = installations
+	}
 }
-*/

--- a/appconfig/options.go
+++ b/appconfig/options.go
@@ -42,10 +42,16 @@ func WithOwnerDefault(name string, paths []string) Option {
 
 // WithPrivateRemotes enables loading remote configuration from private
 // repositories owned by a different user or organization. It uses the app's
-// installation on the remote owner to fetch the referenced file. If the app
-// is not installed on that owner, or an installation client cannot be created,
+// installation on the remote repository to fetch the referenced file. If the
+// app is not installed on that repository, or an installation client cannot be created,
 // the loader logs the failure and falls back to the original client so public
 // remote repositories remain supported.
+//
+// WARNING: Enabling this option can expose configuration file content and
+// repository existence to users who otherwise may not be able to access them.
+// Enable it only when the app is installed on GitHub organizations where all
+// users are trusted, or when the caller otherwise prevents unintentional
+// information disclosure.
 //
 // This loader does not cache installation lookups or clients. Callers that
 // load configuration frequently should pass caching implementations, such as

--- a/appconfig/options.go
+++ b/appconfig/options.go
@@ -14,7 +14,9 @@
 
 package appconfig
 
-import "github.com/palantir/go-githubapp/githubapp"
+import (
+	"github.com/palantir/go-githubapp/githubapp"
+)
 
 type Option func(*Loader)
 


### PR DESCRIPTION
## Before this PR
Coming from https://github.com/palantir/policy-bot/pull/1359 - please review for some additional context on this change.

`appconfig.Loader` can follow remote configuration references, but it always uses the client passed to `LoadConfig`. This prevents an app installation in one organization from reading a private remote configuration repository owned by another organization, even when the app is installed on both.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
`appconfig.WithPrivateRemotes` now enables cross-owner private remote configuration. For a remote owned by a different user or organization, the loader resolves that owner’s app installation and uses an installation-scoped client to fetch the remote file.

Same-owner remotes remain unchanged. If no target installation exists or its client cannot be created, the loader logs the failure and falls back to the original client, preserving support for public remotes.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
Cross-owner remote loads with this option enabled make an additional installation lookup and may create an additional client. Callers with high configuration load volume should use the existing caching `InstallationsService` and `ClientCreator` implementations.